### PR TITLE
Don't use reflection to handle enums

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/InjectionPoint.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/InjectionPoint.java
@@ -266,14 +266,14 @@ public abstract class InjectionPoint {
         return InjectionPoint.parse(at.value(), at.shift(), at.by(), Arrays.asList(at.args()), at.target(), at.ordinal(), at.opcode());
     }
 
-    /**
+    /*
      * Parse an InjectionPoint from the supplied {@link At} annotation supplied as an AnnotationNode instance
      */
     public static InjectionPoint parse(AnnotationNode node) {
         String at = ASMHelper.<String>getAnnotationValue(node, "value");
         List<String> args = ASMHelper.<List<String>>getAnnotationValue(node, "args");
         String target = ASMHelper.<String>getAnnotationValue(node, "target", "");
-        At.Shift shift = ASMHelper.<At.Shift>getAnnotationEnumConstantValue(node, "shift", At.Shift.class, At.Shift.NONE);
+        At.Shift shift = At.Shift.valueOf(ASMHelper.getAnnotationEnumName(node, "shift", At.Shift.NONE.name()));
         int by = ASMHelper.<Integer>getAnnotationValue(node, "by", Integer.valueOf(0));
         int ordinal = ASMHelper.<Integer>getAnnotationValue(node, "ordinal", Integer.valueOf(-1));
         int opcode = ASMHelper.<Integer>getAnnotationValue(node, "opcode", Integer.valueOf(0));

--- a/src/main/java/org/spongepowered/asm/util/ASMHelper.java
+++ b/src/main/java/org/spongepowered/asm/util/ASMHelper.java
@@ -485,25 +485,19 @@ public class ASMHelper {
     }
 
     /**
-     * Get the enum constant referenced by an annotation node
+     * Get the name of the enum constant referred to by an annotation node
      *
      * @param annotationNode Annotation node to query
      * @param key Key to search for
      * @param enumClass Class of enum containing the enum constant to search for
      * @param defaultValue Value to return if the specified key isn't found
      * @return duck-typed annotation value or defaultValue if missing
-     * @throws NoSuchFieldException
      */
     @SuppressWarnings("unchecked")
-    public static <T> T getAnnotationEnumConstantValue(AnnotationNode annotationNode, String key, Class<?> enumClass, T defaultValue) {
-        String[] value = ASMHelper.getAnnotationValue(annotationNode, key);
-        try {
-            Field enumField = enumClass.getField(value[1]);
-            if (enumField.isEnumConstant()) {
-                return (T) enumField;
-            }
-        } catch (NoSuchFieldException e) {
-            // don't care
+    public static String getAnnotationEnumName(AnnotationNode annotationNode, String key, String defaultValue) {
+        String[] value = ASMHelper.getAnnotationValue(annotationNode, key, new String[0]);
+        if (value.length == 2) {
+            return value[1];
         }
         return defaultValue;
     }


### PR DESCRIPTION
It turns out that changes I made earlier didn't work properly, and always caused a `CastClastException` to be thrown.

I've replaced the use of reflection by simply calling `At.valueOf` in `InjectionPoint` with the string that (the renamed method) `getAnnotationEnumName` returns.

I've tested this out with `Sponge` to ensure that it works properly.
