### PR TITLE
Issue with @SoftOverride when supermixin is not applied

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -230,7 +230,7 @@ public class MixinTargetContext implements IReferenceMapperContext {
         // Any method tagged with @SoftOverride must have an implementation visible from 
         if (ASMHelper.getInvisibleAnnotation(method, SoftOverride.class) != null) {
             Method superMethod = this.targetClassInfo.findMethodInHierarchy(method.name, method.desc, false, Traversal.SUPER);
-            if (superMethod == null || !superMethod.isInjected()) {
+            if (superMethod == null) {
                 throw new InvalidMixinException(this, "Mixin method " + method.name + method.desc + " is tagged with @SoftOverride but no "
                         + "valid method was found in superclasses of " + this.targetClass.name);
             }


### PR DESCRIPTION
If a (super)mixin defines a method, and another mixin `@SoftOverride`s that method the transformer will check that the super method is injected, fair enough.
The problem is that it may not have been injected at that point in time, therefore causing errors in certain cases. The transformer knows the super method _will_ be injected because `findMethodInHierarchy` will return null otherwise.
This PR removes the check whether it is injected, however if this is not an acceptable way to fix the issue, this PR can be seen as an issue instead.

As an example of when there are issues is with my persistent entity fix (SpongePowered/Sponge#173)

The mixin `MixinEntity` defines the method `readFromNbt`.
`MixinEntityLivingBase` overrides this method.
All is good when launching the server, but when launching the client, it errors.
Turns out that the server loads the following classes in the order:
`Entity`, `EntityPlayer`, `EntityLivingBase`
But the client loads `EntityPlayer`, `EntityLivingBase` then there is an error applying `MixinEntityLivingBase`