### PR TITLE
Fix @Inject callback methods overriding a callback in a superclass

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -470,8 +470,10 @@ public class CallbackInjector extends Injector {
         if (callback.canCaptureLocals) {
             Locals.loadLocals(callback.localTypes, callback, callback.frameSize);
         }
-        
+
         // Call the callback!
+        // Set to private to avoid overriding callbacks from mixins to superclasses
+        callbackMethod.access = Opcodes.ACC_PRIVATE;
         this.invokeMethod(callback, callbackMethod);
     }
 


### PR DESCRIPTION
### The (obscure) issue ###
A mixin to a class contains an injection, using `@Inject`. The injection is injecting into a constructor and so it has been named `onConstructed`.
E.g.
```java
public class Base {
    public Base() {
    }
}
```
```java
@Mixin(Base.class)
public class MixinBase {
    @Inject(method = "<init>", at = @At("RETURN"))
    public void onConstructed() {
        System.out.println("Base constructed");
    }
}
```
Another mixin is injecting into a different class, but the class has the previous's mixin target in it's hierarchy. This mixin also wants to inject into the constructor, so it defines an injection `onConstructed`.
E.g.
```java
public class Another extends Base {
}
```
```java
@Mixin(Another.class)
public class MixinAnother extends Base {
    @Inject(method = "<init>", at = @At("RETURN"))
    public void onConstructed() {
        System.out.println("Another constructed");
    }
}
```
Now that there are two identical methods, when creating a new instance the `onConstructed` method is only called in the child mixin.
E.g.
`new Another();`
STDOUT = `Another constructed`

The injection to the super class is never called

### Solution ###
Make the injected method private, always. Specifically, the `INVOKESPECIAL` will always reference the correct class (from my understanding) and so it won't override.

I do not know the exact place where it should be made private, so I just did it right before the invocation instruction is appended. Is it possible to change the access back to what it was (likely public) after appending the instruction?

### A real example in Sponge ###
Spawn a minecart, now call `minecart.getType()`. It will return `null` because the type is set in the `onConstructed` method in `MixinEntity`, but was overridden by `onConstructed` in `MixinEntityMinecart`.
(In fact, if you have the entity activation module active, it will error automatically because it calls `getType()` during a tick cycle. (Which is how I initially discovered the issue))