### PR TITLE
Make ClassInfo.Traversal actually use the provided traverse parameter

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -93,7 +93,7 @@ class ClassInfo extends TreeInfo {
         
         private Traversal(Traversal next, boolean traverse) {
             this.next = next != null ? next : this;
-            this.traverse = true;
+            this.traverse = traverse;
         }
         
         public Traversal next() {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -268,7 +268,7 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
                 continue;
             }
             
-            if (!targetClass.hasSuperClass(classNode.superName, ClassInfo.Traversal.NONE)) {
+            if (!targetClass.hasSuperClass(classNode.superName, ClassInfo.Traversal.IMMEDIATE)) {
                 throw new InvalidMixinException(this, "Super class '" + classNode.superName.replace('/', '.') + "' of " + this.name
                         + " was not found in the hierarchy of target class '" + targetClass + "'");
             }


### PR DESCRIPTION
The `traverse` parameter was being ignored in `ClassInfo.Traversal`, this PR fixes that.

I had to change the traversal from `NONE` to `IMMEDIATE` when searching for the superclass because it errored many times when the `traverse` field was false. I presume the traversal type was wrong in the first place.