### PR TITLE
Make the MixinBootstrap init methods public

### DIFF
--- a/src/main/java/org/spongepowered/asm/launch/MixinBootstrap.java
+++ b/src/main/java/org/spongepowered/asm/launch/MixinBootstrap.java
@@ -116,7 +116,7 @@ public abstract class MixinBootstrap {
     /**
      * Phase 1 of mixin initialisation
      */
-    static boolean preInit() {
+    public static boolean preInit() {
         Object registeredVersion = Launch.blackboard.get(MixinBootstrap.INIT_KEY);
         if (registeredVersion != null) {
             if (!registeredVersion.equals(MixinBootstrap.VERSION)) {
@@ -149,7 +149,7 @@ public abstract class MixinBootstrap {
     /**
      * Phase 2 of mixin initialisation, register the state tweaker
      */
-    static void register() {
+    public static void register() {
         if (!MixinBootstrap.initialised) {
             throw new IllegalStateException("MixinBootstrap.register() called before MixinBootstrap.preInit()");
         }


### PR DESCRIPTION
This allows external tweakers who wish to control the launch process (like FE, for example) to conduct the Mixin initialization.

Currently, only MixinBootstrap.init() is exposed to external tweakers, and it has been stated that MixinBootstrap.init() will not work in production. Thus, either I live life dangerously by holding my own instance of MixinTweaker, or create a class in org.spongepowered.asm.launch (potentially dangerous too) or I make this PR.