### PR TITLE
Add support for lambda expressions inside mixins

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MemberRef.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MemberRef.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
-import org.spongepowered.asm.lib.Handle;
 import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.lib.tree.FieldInsnNode;
 import org.spongepowered.asm.lib.tree.MethodInsnNode;
@@ -42,7 +41,7 @@ public abstract class MemberRef {
     /**
      * A static reference to a method backed by an invoke instruction
      */
-    public static final class StaticMethodRef extends MemberRef {
+    public static final class Method extends MemberRef {
 
         /**
          * Method invocation instruction
@@ -54,7 +53,7 @@ public abstract class MemberRef {
          *
          * @param insn Method instruction of this member reference
          */
-        public StaticMethodRef(MethodInsnNode insn) {
+        public Method(MethodInsnNode insn) {
             this.insn = insn;
         }
 
@@ -97,7 +96,7 @@ public abstract class MemberRef {
     /**
      * A static reference to a field backed by field get/put instruction
      */
-    public static final class StaticFieldRef extends MemberRef {
+    public static final class Field extends MemberRef {
 
         /**
          * Field accessor instruction
@@ -109,7 +108,7 @@ public abstract class MemberRef {
          *
          * @param insn Field instruction this member reference
          */
-        public StaticFieldRef(FieldInsnNode insn) {
+        public Field(FieldInsnNode insn) {
             this.insn = insn;
         }
 
@@ -152,9 +151,9 @@ public abstract class MemberRef {
     /**
      * A reference to a field or method backed by a method handle
      */
-    public static final class HandleRef extends MemberRef {
+    public static final class Handle extends MemberRef {
 
-        private Handle handle;
+        private org.spongepowered.asm.lib.Handle handle;
 
         /**
          * Creates a member reference initially referring to the member referred
@@ -163,7 +162,7 @@ public abstract class MemberRef {
          *
          * @param handle Initial method handle.
          */
-        public HandleRef(Handle handle) {
+        public Handle(org.spongepowered.asm.lib.Handle handle) {
             this.handle = handle;
         }
 
@@ -172,7 +171,7 @@ public abstract class MemberRef {
          *
          * @return Method handle representing this object
          */
-        public Handle getMethodHandle() {
+        public org.spongepowered.asm.lib.Handle getMethodHandle() {
             return this.handle;
         }
 
@@ -227,7 +226,7 @@ public abstract class MemberRef {
 
         @Override
         public void setOwner(String owner) {
-            this.handle = new Handle(this.handle.getTag(), owner, this.handle.getName(), this.handle.getDesc());
+            this.handle = new org.spongepowered.asm.lib.Handle(this.handle.getTag(), owner, this.handle.getName(), this.handle.getDesc());
         }
 
         @Override
@@ -242,7 +241,7 @@ public abstract class MemberRef {
 
         @Override
         public void setDesc(String desc) {
-            this.handle = new Handle(this.handle.getTag(), this.handle.getOwner(), this.handle.getName(), desc);
+            this.handle = new org.spongepowered.asm.lib.Handle(this.handle.getTag(), this.handle.getOwner(), this.handle.getName(), desc);
         }
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MemberRef.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MemberRef.java
@@ -1,0 +1,321 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import org.spongepowered.asm.lib.Handle;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.lib.tree.FieldInsnNode;
+import org.spongepowered.asm.lib.tree.MethodInsnNode;
+import org.spongepowered.asm.util.ASMHelper;
+
+/**
+ * Reference to a field or method that also includes invocation
+ * instructions.
+ *
+ * To instances are defined to be equal if they both refer to the same method
+ * and have the same invocation instructions.
+ */
+public abstract class MemberRef {
+
+    /**
+     * A static reference to a method backed by an invoke instruction
+     */
+    public static final class StaticMethodRef extends MemberRef {
+
+        /**
+         * Method invocation instruction
+         */
+        public final MethodInsnNode insn;
+
+        /**
+         * ctor
+         *
+         * @param insn Method instruction of this member reference
+         */
+        public StaticMethodRef(MethodInsnNode insn) {
+            this.insn = insn;
+        }
+
+        @Override
+        public boolean isField() {
+            return false;
+        }
+
+        @Override
+        public int getOpcode() {
+            return this.insn.getOpcode();
+        }
+
+        @Override
+        public String getOwner() {
+            return this.insn.owner;
+        }
+
+        @Override
+        public void setOwner(String owner) {
+            this.insn.owner = owner;
+        }
+
+        @Override
+        public String getName() {
+            return this.insn.name;
+        }
+
+        @Override
+        public String getDesc() {
+            return this.insn.desc;
+        }
+
+        @Override
+        public void setDesc(String desc) {
+            this.insn.desc = desc;
+        }
+    }
+
+    /**
+     * A static reference to a field backed by field get/put instruction
+     */
+    public static final class StaticFieldRef extends MemberRef {
+
+        /**
+         * Field accessor instruction
+         */
+        public final FieldInsnNode insn;
+
+        /**
+         * ctor
+         *
+         * @param insn Field instruction this member reference
+         */
+        public StaticFieldRef(FieldInsnNode insn) {
+            this.insn = insn;
+        }
+
+        @Override
+        public boolean isField() {
+            return true;
+        }
+
+        @Override
+        public int getOpcode() {
+            return this.insn.getOpcode();
+        }
+
+        @Override
+        public String getOwner() {
+            return this.insn.owner;
+        }
+
+        @Override
+        public void setOwner(String owner) {
+            this.insn.owner = owner;
+        }
+
+        @Override
+        public String getName() {
+            return this.insn.name;
+        }
+
+        @Override
+        public String getDesc() {
+            return this.insn.desc;
+        }
+
+        @Override
+        public void setDesc(String desc) {
+            this.insn.desc = desc;
+        }
+    }
+
+    /**
+     * A reference to a field or method backed by a method handle
+     */
+    public static final class HandleRef extends MemberRef {
+
+        private Handle handle;
+
+        /**
+         * Creates a member reference initially referring to the member referred
+         * to by the method handle and the invocation instruction of the method
+         * handle.
+         *
+         * @param handle Initial method handle.
+         */
+        public HandleRef(Handle handle) {
+            this.handle = handle;
+        }
+
+        /**
+         * Gets a method handle for the member this is object is referring to.
+         *
+         * @return Method handle representing this object
+         */
+        public Handle getMethodHandle() {
+            return this.handle;
+        }
+
+        @Override
+        public boolean isField() {
+            switch (this.handle.getTag()) {
+                case Opcodes.H_INVOKEVIRTUAL:
+                case Opcodes.H_INVOKESTATIC:
+                case Opcodes.H_INVOKEINTERFACE:
+                case Opcodes.H_INVOKESPECIAL:
+                case Opcodes.H_NEWINVOKESPECIAL:
+                    return false;
+                case Opcodes.H_GETFIELD:
+                case Opcodes.H_GETSTATIC:
+                case Opcodes.H_PUTFIELD:
+                case Opcodes.H_PUTSTATIC:
+                    return true;
+                default:
+                    throw new MixinTransformerError("Invalid tag " + this.handle.getTag() + " for method handle " + this.handle + ".");
+            }
+        }
+
+        @Override
+        public int getOpcode() {
+            switch (this.handle.getTag()) {
+                case Opcodes.H_INVOKEVIRTUAL:
+                    return Opcodes.INVOKEVIRTUAL;
+                case Opcodes.H_INVOKESTATIC:
+                    return Opcodes.INVOKESTATIC;
+                case Opcodes.H_INVOKEINTERFACE:
+                    return Opcodes.INVOKEINTERFACE;
+                case Opcodes.H_INVOKESPECIAL:
+                case Opcodes.H_NEWINVOKESPECIAL:
+                    return Opcodes.INVOKESPECIAL;
+                case Opcodes.H_GETFIELD:
+                    return Opcodes.GETFIELD;
+                case Opcodes.H_GETSTATIC:
+                    return Opcodes.GETSTATIC;
+                case Opcodes.H_PUTFIELD:
+                    return Opcodes.PUTFIELD;
+                case Opcodes.H_PUTSTATIC:
+                    return Opcodes.PUTSTATIC;
+                default:
+                    throw new MixinTransformerError("Invalid tag " + this.handle.getTag() + " for method handle " + this.handle + ".");
+            }
+        }
+
+        @Override
+        public String getOwner() {
+            return this.handle.getOwner();
+        }
+
+        @Override
+        public void setOwner(String owner) {
+            this.handle = new Handle(this.handle.getTag(), owner, this.handle.getName(), this.handle.getDesc());
+        }
+
+        @Override
+        public String getName() {
+            return this.handle.getName();
+        }
+
+        @Override
+        public String getDesc() {
+            return this.handle.getDesc();
+        }
+
+        @Override
+        public void setDesc(String desc) {
+            this.handle = new Handle(this.handle.getTag(), this.handle.getOwner(), this.handle.getName(), desc);
+        }
+    }
+
+    /**
+     * Whether this member is a field.
+     *
+     * @return If this member is a field, else it is a method
+     */
+    public abstract boolean isField();
+
+    /**
+     * The opcode of the invocation.
+     *
+     * @return The opcode of the invocation
+     */
+    public abstract int getOpcode();
+
+    /**
+     * The internal name for the owner of this member.
+     *
+     * @return The owners name
+     */
+    public abstract String getOwner();
+
+    /**
+     * Changes the owner of this
+     *
+     * @param owner New owner
+     */
+    public abstract void setOwner(String owner);
+
+    /**
+     * Name of this member.
+     *
+     * @return Name of this member.
+     */
+    public abstract String getName();
+
+    /**
+     * Descriptor of this member.
+     *
+     * @return Descriptor of this member
+     */
+    public abstract String getDesc();
+
+    /**
+     * Changes the descriptor of this member
+     *
+     * @param desc New descriptor of this member
+     */
+    public abstract void setDesc(String desc);
+
+    @Override
+    public String toString() {
+        return ASMHelper.getOpcodeName(this.getOpcode()) + " for "
+                + this.getOwner() + "." + this.getName() + (this.isField() ? ":" : "") + this.getDesc();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof MemberRef)) {
+            return false;
+        }
+
+        MemberRef other = (MemberRef)obj;
+        return this.getOpcode() == other.getOpcode()
+                && this.getOwner().equals(other.getOwner())
+                && this.getName().equals(other.getName())
+                && this.getDesc().equals(other.getDesc());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinClassWriter.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinClassWriter.java
@@ -53,10 +53,10 @@ public class MixinClassWriter extends ClassWriter {
         ClassInfo d = ClassInfo.forName(type2);
         
         if (c.hasSuperClass(d)) {
-            return type1;
+            return type2;
         }
         if (d.hasSuperClass(c)) {
-            return type2;
+            return type1;
         }
         if (c.isInterface() || d.isInterface()) {
             return MixinClassWriter.JAVA_LANG_OBJECT;
@@ -68,7 +68,7 @@ public class MixinClassWriter extends ClassWriter {
                 return MixinClassWriter.JAVA_LANG_OBJECT;
             }
             
-        } while (!c.hasSuperClass(d));
+        } while (!d.hasSuperClass(c));
         
         return c.getName();
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessor.java
@@ -130,6 +130,7 @@ class MixinPreProcessor {
     MixinTargetContext createContextFor(ClassNode target) {
         this.prepare();
         MixinTargetContext context = new MixinTargetContext(this.mixin, this.classNode, target);
+        target.version = Math.max(this.classNode.version, target.version);
         this.attach(context);
         return context;
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -392,7 +392,6 @@ public class MixinTargetContext implements IReferenceMapperContext {
      * @param handle Handle to transform
      */
     private Handle transformHandle(MethodNode method, Iterator<AbstractInsnNode> iter, Handle handle) {
-        this.targetClass.version = Constants.JAVA8_CLASSFILE_VERSION;
         MemberRef.HandleRef memberRef = new MemberRef.HandleRef(handle);
         if (memberRef.isField()) {
             this.transformFieldRef(method, iter, memberRef);

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -719,7 +719,7 @@ public class MixinTargetContext implements IReferenceMapperContext {
     }
 
     /**
-     * Called imm imediately after the mixin is applied to targetClass
+     * Called imediately after the mixin is applied to targetClass
      * 
      * @param transformedName Target class's transformed name
      * @param targetClass Target class

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -358,7 +358,7 @@ public class MixinTargetContext implements IReferenceMapperContext {
      * @param dynInsn Insn to transform
      */
     private void transformInvokeDynamicNode(MethodNode method, Iterator<AbstractInsnNode> iter, InvokeDynamicInsnNode dynInsn) {
-        System.out.println(targetClass.version);
+        // set class version to java 8
         targetClass.version = 52;
         dynInsn.desc = this.transformMethodDescriptor(dynInsn.desc);
         dynInsn.bsm = this.transformHandle(method, iter, dynInsn.bsm);

--- a/src/main/java/org/spongepowered/asm/util/Constants.java
+++ b/src/main/java/org/spongepowered/asm/util/Constants.java
@@ -32,7 +32,6 @@ import org.spongepowered.asm.mixin.Mixin;
  */
 public abstract class Constants {
 
-    public static final int JAVA8_CLASSFILE_VERSION = 52;
     public static final String INIT = "<init>";
     public static final String CLINIT = "<clinit>";
     public static final String IMAGINARY_SUPER = "super$";

--- a/src/main/java/org/spongepowered/asm/util/Constants.java
+++ b/src/main/java/org/spongepowered/asm/util/Constants.java
@@ -32,6 +32,7 @@ import org.spongepowered.asm.mixin.Mixin;
  */
 public abstract class Constants {
 
+    public static final int JAVA8_CLASSFILE_VERSION = 52;
     public static final String INIT = "<init>";
     public static final String CLINIT = "<clinit>";
     public static final String IMAGINARY_SUPER = "super$";


### PR DESCRIPTION
To explain the changes I will introduce some terms that relates in the changes made to the class file format in java 7 and how lambdas are implemented.

### Method Handle

Is an object that can directly execute a specified method, it holds and reference to the particular method and how to execute it, either with an invokevirtual, invokespecial, invokestatic or invokeinterface instruction. It is similar to java.lang.Mathod in some sense but it is a lot faster and is designed for execution rather than introspection. 

### Callsite

A Callsite is basically a holder for a method handle. They can either be constant or mutable(can change the method handle inside it).

### Invoke dynamic

A bytecode instruction that allows runtime linking. The first time the particular instruction is executed it calls what is called a bootstrap method which takes the name and description of the method as well as some constant arguments(arguments from the constant pool of the class) and return a Callsite. On that and any further execution of the invoke dynamic instruction the method inside the Callsite is invoked directly.

Lambda expressions use the invoke dynamic instruction to create the object representing the lambda(instance of the functional interface). It uses either java.lang.invoke.LambdaMetafactory.metafactory(...) or java.lang.invoke.LambdaMetafactory.altMetafactory(...) as its bootstrap method. The method behind invokedynamic instruction takes the local variables referenced in the lambda expression.

Javac also spits out a private method that contains all of the code that is within the lambda expression. And a Method Handle of that method is passed to the bootstrap method. 

So to support lambda expression the mixin transformer will transform invoke dynamic instructions in the same way as it transforms other invoke instructions as well as transforming the constant MethodHandle arguments it takes. To implement this I created an abstraction MemberRef that abstract over both Method Handles and bytecode invoke/field instructions.

Note any mixin class that has an invokedynamic instruction in it will now have the target class, class file version set to 52(java 8).

How do you guys test changes , to test it myself I added some tests inside of a sponge mixins and it works on both lambdas that don't refer to any shadow members and ones that do.   