### PR TITLE
[WIP]Interface mixins

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -92,6 +92,8 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
      */
     private final transient Set<String> syntheticInnerClasses = new HashSet<String>();
 
+    private final transient Map<String, List<MixinInfo>> interfaceMixins = new HashMap<String, List<MixinInfo>>();
+
     /**
      * Minimum version of the mixin subsystem required to correctly apply mixins
      * in this configuration. 
@@ -310,6 +312,12 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
                 for (String innerClass : mixin.getSyntheticInnerClasses()) {
                     this.syntheticInnerClasses.add(innerClass.replace('/', '.'));
                 }
+                for (ClassInfo target : mixin.getInterfacesTargeted()) {
+                    if (!this.interfaceMixins.containsKey(target.getName())) {
+                        this.interfaceMixins.put(target.getName(), new ArrayList<MixinInfo>());
+                    }
+                    this.interfaceMixins.get(target.getName()).add(mixin);
+                }
             } catch (Exception ex) {
                 this.logger.error(ex.getMessage(), ex);
                 this.removeMixin(mixin);
@@ -503,6 +511,10 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
             this.mixinMapping.put(targetClass, mixins);
         }
         return mixins;
+    }
+
+    public Map<String, List<MixinInfo>> getInterfaceMixins() {
+        return this.interfaceMixins;
     }
     
     @Override

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -92,6 +92,9 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
      */
     private final transient Set<String> syntheticInnerClasses = new HashSet<String>();
 
+    /**
+     * Interface mixins in this config
+     */
     private final transient Map<String, List<MixinInfo>> interfaceMixins = new HashMap<String, List<MixinInfo>>();
 
     /**
@@ -312,11 +315,12 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
                 for (String innerClass : mixin.getSyntheticInnerClasses()) {
                     this.syntheticInnerClasses.add(innerClass.replace('/', '.'));
                 }
-                for (ClassInfo target : mixin.getInterfacesTargeted()) {
-                    if (!this.interfaceMixins.containsKey(target.getName())) {
-                        this.interfaceMixins.put(target.getName(), new ArrayList<MixinInfo>());
+                for (ClassInfo target : mixin.getInterfaceTargets()) {
+                    String targetName = target.getName().replace('/', '.');
+                    if (!this.interfaceMixins.containsKey(targetName)) {
+                        this.interfaceMixins.put(targetName, new ArrayList<MixinInfo>());
                     }
-                    this.interfaceMixins.get(target.getName()).add(mixin);
+                    this.interfaceMixins.get(targetName).add(mixin);
                 }
             } catch (Exception ex) {
                 this.logger.error(ex.getMessage(), ex);
@@ -350,7 +354,7 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
             
             try {
                 MixinInfo mixin = new MixinInfo(this, mixinClass, true, this.plugin, suppressPlugin);
-                if (mixin.getTargetClasses().size() > 0) {
+                if (mixin.getTargetClasses().size() > 0 || mixin.getInterfaceTargets().size() > 0) {
                     MixinConfig.globalMixinList.add(fqMixinClass);
                     for (String targetClass : mixin.getTargetClasses()) {
                         String targetClassName = targetClass.replace('/', '.');
@@ -513,6 +517,9 @@ class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
         return mixins;
     }
 
+    /**
+     * Mapping of targeted interfaces with a list of mixins that target it
+     */
     public Map<String, List<MixinInfo>> getInterfaceMixins() {
         return this.interfaceMixins;
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -161,6 +161,8 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
      */
     private boolean detachedSuper;
 
+    private List<ClassInfo> interfacesTargeted = new ArrayList<ClassInfo>();
+
     /**
      * Internal ctor, called by {@link MixinConfig}
      * 
@@ -188,6 +190,11 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
         this.targetClassNames = Collections.unmodifiableList(Lists.transform(this.targetClasses, Functions.toStringFunction()));
         this.validationClassNode = classNode;
         this.classInfo = ClassInfo.fromClassNode(classNode);
+        for (ClassInfo target : this.targetClasses) {
+            if (target.isInterface()) {
+                this.interfacesTargeted.add(target);
+            }
+        }
     }
     
     void validate() {
@@ -427,6 +434,10 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
     @Override
     public boolean isDetachedSuper() {
         return this.detachedSuper;
+    }
+
+    public List<ClassInfo> getInterfacesTargeted() {
+        return this.interfacesTargeted;
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -26,11 +26,7 @@ package org.spongepowered.asm.mixin.transformer;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.launchwrapper.LaunchClassLoader;
@@ -161,6 +157,9 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
      */
     private boolean detachedSuper;
 
+    /**
+     * Get all interfaces it targets
+     */
     private List<ClassInfo> interfacesTargeted = new ArrayList<ClassInfo>();
 
     /**
@@ -190,9 +189,12 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
         this.targetClassNames = Collections.unmodifiableList(Lists.transform(this.targetClasses, Functions.toStringFunction()));
         this.validationClassNode = classNode;
         this.classInfo = ClassInfo.fromClassNode(classNode);
-        for (ClassInfo target : this.targetClasses) {
+        Iterator<ClassInfo> iter = this.targetClasses.iterator();
+        while (iter.hasNext()) {
+            ClassInfo target = iter.next();
             if (target.isInterface()) {
                 this.interfacesTargeted.add(target);
+                iter.remove();
             }
         }
     }
@@ -249,9 +251,6 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
                 ClassInfo targetInfo = ClassInfo.forName(targetClassName);
                 if (targetInfo == null) {
                     throw new RuntimeException("@Mixin target " + targetClassName + " was not found " + this);
-                }
-                if (targetInfo.isInterface()) {
-                    throw new InvalidMixinException(this, "@Mixin target " + targetClassName + " is an interface in " + this);
                 }
                 if (checkPublic && targetInfo.isPublic()) {
                     throw new InvalidMixinException(this, "@Mixin target " + targetClassName + " is public in " + this
@@ -436,7 +435,10 @@ class MixinInfo extends TreeInfo implements Comparable<MixinInfo>, IMixinInfo {
         return this.detachedSuper;
     }
 
-    public List<ClassInfo> getInterfacesTargeted() {
+    /**
+     * Interfaces that the mixin targets
+     */
+    public List<ClassInfo> getInterfaceTargets() {
         return this.interfacesTargeted;
     }
 


### PR DESCRIPTION
As requested by @bloodmc and in issue #69, this PR implements interface mixins, mixins that target a class implementing the declared class instead of the declared class itself.

This is currently a simply solution and doesn't take into account more complex situation that can occur which must be worked out before this is merged.

This behaviour works for all mixin targets that are interfaces, so one mixin can target both interfaces and classes.

## Example

```java
@Mixin(IInventory.class)
public abstract class MixinInventory implements IInventory{

    private String name;

    public int size() {
        return this.getSizeInventory();
    }
}
```

Which mixs the method/field into the top most implementations of IInventory(classes who superclass doesn't implement IIventory). Which means TileEntityLockable gets this mixin mixed in where as TileEntityChest doesn't as it extends TileEntityLockable.

Note it must extend the interface you want(directly or indirectly) to access the methods in the interface. Shadowing doesn't work as it targets the implementation not the interface and if the implementation is abstract then it will fail.

## Implementation

MixinTransformer/MixinConfig/MixinInfo keep track of the mixins that are interface mixins and the mapping between the interfaces and the mixins.  When a class is transformed it first does a depth-first search to find all interface mixins by loading each superinterface and superclass and calculating their interface mixins. Note this only slightly changes the order of the classloading of the interfaces and superclass as they would immediately loading anyways after it finished transforming and I have not seen a problem.