### PR TITLE
Fix version detection when using Java 9

### DIFF
--- a/src/main/java/org/spongepowered/asm/util/JavaVersion.java
+++ b/src/main/java/org/spongepowered/asm/util/JavaVersion.java
@@ -45,9 +45,14 @@ public abstract class JavaVersion {
 
     private static double resolveCurrentVersion() {
         String version = System.getProperty("java.version");
-        Matcher matcher = Pattern.compile("[0-9]+\\.[0-9]+").matcher(version);
+        Matcher matcher = Pattern.compile("[0-9]+\\.[0-9]+").matcher(version); // Java 8 and earlier
         if (matcher.find()) {
             return Double.parseDouble(matcher.group());
+        } else {
+            matcher = Pattern.compile("[0-9]+"); // Java 9 and later
+            if (matcher.find()) {
+                return Double.parseDouble(matcher.group());
+            }
         }
         return 1.6;
     }

--- a/src/main/java/org/spongepowered/asm/util/JavaVersion.java
+++ b/src/main/java/org/spongepowered/asm/util/JavaVersion.java
@@ -49,7 +49,7 @@ public abstract class JavaVersion {
         if (matcher.find()) {
             return Double.parseDouble(matcher.group());
         } else {
-            matcher = Pattern.compile("[0-9]+"); // Java 9 and later
+            matcher = Pattern.compile("[0-9]+").matcher(version); // Java 9 and later
             if (matcher.find()) {
                 return Double.parseDouble(matcher.group());
             }


### PR DESCRIPTION
The latest Java 9 preview build's version property is `9-internal`. Sponge's Mixin (https://github.com/SpongePowered/Mixin/blob/initphase/src/main/java/org/spongepowered/asm/util/JavaVersion.java#L48) still expects the version string to be in the form `x.x`, like `1.8.0_xx-internal`. This pull request will allow us to start preparing for the release of Java 9 ahead of time by not breaking when we are using it.