### PR TITLE
Pretty print the cause of a throwable

### DIFF
--- a/src/main/java/org/spongepowered/asm/util/PrettyPrinter.java
+++ b/src/main/java/org/spongepowered/asm/util/PrettyPrinter.java
@@ -683,8 +683,12 @@ public class PrettyPrinter {
      * @return fluent interface
      */
     public PrettyPrinter add(Throwable th, int indent) {
-        this.add("%s: %s", th.getClass().getName(), th.getMessage());
-        return this.add(th.getStackTrace(), indent);
+        while (th != null) {
+            this.add("%s: %s", th.getClass().getName(), th.getMessage());
+            this.add(th.getStackTrace(), indent);
+            th = th.getCause();
+        }
+        return this;
     }
     
     /**


### PR DESCRIPTION
Before:
```
/* Stacktrace:                                                                                                                     */
/* com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Invalid locale format: en_gb */
/*     com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2201)                                                        */
/*     com.google.common.cache.LocalCache.get(LocalCache.java:3934)                                                                */
/*     com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3938)                                                          */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4821)                                              */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4827)                                     */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketFunction.lambda$10(PacketFunction.java:900)                      */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketPhase.unwind(PacketPhase.java:320)                               */
/*     org.spongepowered.common.event.tracking.CauseTracker.completePhase(CauseTracker.java:190)                                   */
/*     org.spongepowered.common.network.PacketUtil.onProcessPacket(PacketUtil.java:130)                                            */
/*     net.minecraft.network.PacketThreadUtil$1.redirect$onProcessPacket$zjc000(PacketThreadUtil.java:39)                          */
/*     net.minecraft.network.PacketThreadUtil$1.run(PacketThreadUtil.java:15)                                                      */
/*     java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)                                                         */
/*     java.util.concurrent.FutureTask.run(Unknown Source)                                                                         */
/*     net.minecraft.util.Util.runTask(Util.java:25)                                                                               */
/*     net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:742)                                   */
/*     net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:408)                         */
/*     net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:687)                                                         */
/*     net.minecraft.server.MinecraftServer.run(MinecraftServer.java:536)                                                          */
/*     java.lang.Thread.run(Unknown Source)                                                                                        */
/***********************************************************************************************************************************/
```
After:
```
/* Stacktrace:                                                                                                                     */
/* com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Invalid locale format: en_gb */
/*     com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2201)                                                        */
/*     com.google.common.cache.LocalCache.get(LocalCache.java:3934)                                                                */
/*     com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3938)                                                          */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4821)                                              */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4827)                                     */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketFunction.lambda$10(PacketFunction.java:900)                      */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketPhase.unwind(PacketPhase.java:320)                               */
/*     org.spongepowered.common.event.tracking.CauseTracker.completePhase(CauseTracker.java:190)                                   */
/*     org.spongepowered.common.network.PacketUtil.onProcessPacket(PacketUtil.java:130)                                            */
/*     net.minecraft.network.PacketThreadUtil$1.redirect$onProcessPacket$zjc000(PacketThreadUtil.java:39)                          */
/*     net.minecraft.network.PacketThreadUtil$1.run(PacketThreadUtil.java:15)                                                      */
/*     java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)                                                         */
/*     java.util.concurrent.FutureTask.run(Unknown Source)                                                                         */
/*     net.minecraft.util.Util.runTask(Util.java:25)                                                                               */
/*     net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:742)                                   */
/*     net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:408)                         */
/*     net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:687)                                                         */
/*     net.minecraft.server.MinecraftServer.run(MinecraftServer.java:536)                                                          */
/*     java.lang.Thread.run(Unknown Source)                                                                                        */
/* java.lang.IllegalArgumentException: Invalid locale format: en_gb                                                                */
/*     org.apache.commons.lang3.LocaleUtils.toLocale(LocaleUtils.java:142)                                                         */
/*     org.spongepowered.common.util.LanguageUtil$1.load(LanguageUtil.java:45)                                                     */
/*     org.spongepowered.common.util.LanguageUtil$1.load(LanguageUtil.java:1)                                                      */
/*     com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3524)                                   */
/*     com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2317)                                                   */
/*     com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2280)                                            */
/*     com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2195)                                                        */
/*     com.google.common.cache.LocalCache.get(LocalCache.java:3934)                                                                */
/*     com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3938)                                                          */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4821)                                              */
/*     com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4827)                                     */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketFunction.lambda$10(PacketFunction.java:900)                      */
/*     org.spongepowered.common.event.tracking.phase.packet.PacketPhase.unwind(PacketPhase.java:320)                               */
/*     org.spongepowered.common.event.tracking.CauseTracker.completePhase(CauseTracker.java:190)                                   */
/*     org.spongepowered.common.network.PacketUtil.onProcessPacket(PacketUtil.java:130)                                            */
/*     net.minecraft.network.PacketThreadUtil$1.redirect$onProcessPacket$zjc000(PacketThreadUtil.java:39)                          */
/*     net.minecraft.network.PacketThreadUtil$1.run(PacketThreadUtil.java:15)                                                      */
/*     java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)                                                         */
/*     java.util.concurrent.FutureTask.run(Unknown Source)                                                                         */
/*     net.minecraft.util.Util.runTask(Util.java:25)                                                                               */
/*     net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:742)                                   */
/*     net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:408)                         */
/*     net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:687)                                                         */
/*     net.minecraft.server.MinecraftServer.run(MinecraftServer.java:536)                                                          */
/*     java.lang.Thread.run(Unknown Source)                                                                                        */
/***********************************************************************************************************************************/
```