### PR TITLE
Add additional debugging metadata using the SourceDebugExtension attribute

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -380,6 +380,30 @@ public final class MixinEnvironment implements ITokenProvider {
         IGNORE_CONSTRAINTS("ignoreConstraints"),
 
         /**
+         * Adds additional debugging information to the target classes that can
+         * used for debugging code injected by Mixins. Please note that the
+         * format is specific to Mixin classes and requires a modification of
+         * your IDE (e.g. a plugin) to support debugging Mixin code.
+         *
+         * <p>The additional debugging information is added as the
+         * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.11">
+         * SourceDebugExtension</a> attribute on the target class with the
+         * following format (example):</p>
+         *
+         * <pre>{@code MIXIN
+         * com.example.mixin.MixinExample run()V handler$onRun$zza000(Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V
+         * com.example.mixin.MixinExtra runExtra()V}</pre>
+         *
+         * <p>The source debug extension consists out of the identifier
+         * {@code MIXIN} and a list of full-qualified names of Mixin classes
+         * that have been applied to the Mixin, each separated by a new line
+         * ({@code \n}). Each Mixin class line is followed by a space-separated
+         * list of method names and descriptors that have been merged from the
+         * Mixin into the target class.</p>
+         */
+        SOURCE_DEBUG_EXTENSION("sourceDebugExtension"),
+
+        /**
          * Enables the hot-swap agent
          */
         HOT_SWAP("hotSwap"),

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
@@ -608,6 +608,11 @@ public class MixinTransformer extends TreeTransformer {
      */
     private void selectModules(MixinEnvironment environment) {
         this.modules.clear();
+
+        // Generate source debug extension attribute if option is enabled
+        if (environment.getOption(Option.SOURCE_DEBUG_EXTENSION)) {
+            this.modules.add(new MixinTransformerModuleSourceDebugExtension());
+        }
         
         // Run CheckClassAdapter on the mixin bytecode if debug option is enabled 
         if (environment.getOption(Option.DEBUG_VERIFY)) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformerModuleSourceDebugExtension.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformerModuleSourceDebugExtension.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.spongepowered.asm.lib.tree.AnnotationNode;
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.lib.tree.MethodNode;
+import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
+import org.spongepowered.asm.util.ASMHelper;
+
+public class MixinTransformerModuleSourceDebugExtension implements IMixinTransformerModule {
+
+    @Override
+    public void preApply(TargetClassContext context) {
+    }
+
+    @Override
+    public void postApply(TargetClassContext context) {
+        ClassNode classNode = context.getClassNode();
+
+        Multimap<String, String> mixins = ArrayListMultimap.create();
+
+        for (MethodNode method : classNode.methods) {
+            AnnotationNode merged = ASMHelper.getVisibleAnnotation(method, MixinMerged.class);
+            if (merged == null) {
+                continue;
+            }
+
+            String owner = ASMHelper.getAnnotationValue(merged, "mixin");
+            mixins.put(owner, method.name + method.desc);
+        }
+
+        StringBuilder builder = new StringBuilder("MIXIN\n");
+
+        for (String mixin : mixins.keySet()) {
+            builder.append(mixin);
+
+            for (String method : mixins.get(mixin)) {
+                builder.append(' ').append(method);
+            }
+
+            builder.append('\n');
+        }
+
+        classNode.sourceDebug = builder.toString();
+    }
+
+}


### PR DESCRIPTION
**TL;DR:** With these changes it is possible to debug Mixins using their original source files, the same way you can debug regular Java classes. It requires a modification of the IDE - for IntelliJ IDEA I've made these changes in a PR to [MinecraftDev](https://minecraftdev.org): https://github.com/minecraft-dev/MinecraftDev/pull/115. Once all changes are merged installing MinecraftDev is the only step needed to debug Mixins.

---

### The issue
Mixin classes are merged into the target classes at runtime. Because of that, debugging Mixins usually results in jumping around on invalid lines in the source of the target class instead of in the actual Mixin code.

The debugger resolves the source location using the class name and the `SourceFile` attribute of the Java class file, which is limited to a single source file. Consequently, debugging methods in the target class and a Mixin is not possible at the same time: the `SourceFile` can be only set to  the original source file or the source file of the Mixin.

### Using decompiled code
Up to now, the only solution for this problem was to use special support in the IDE (primarily IntelliJ IDEA) to debug using decompiled classes instead of the original sources. However, while you are able to see the classes exactly the way they are executed at runtime (including the invocation of injectors etc) it has several disadvantages:

- Requires manual setup to configure Mixin to dump the bytecode and add it to the module classpath
- Comments and the original code formatting is removed due to the decompilation
- Breakpoints can be only set after the Mixin has already been applied once. To add a breakpoint for a new Mixin you have to run the application once to dump the new bytecode and let the IDE refresh all classes until you can actually see your changes in the target class.

### Source debug extension
As already mentioned, Java supports only a single `SourceFile` attribute in the class file. This is not only a problem for Mixin, but also for other projects, primarily programming languages which are compiled to Java source code before getting compiled to the final bytecode.

A solution for this problem was added to Java as part of [JSR-045 (Debugging Support for Other Languages)](https://jcp.org/en/jsr/detail?id=45). It describes a new attribute in the Java class file format, the `SourceDebugExtension` attribute, together with a standardized Source Map Format (SMAP).

SMAP was primarily developed for languages which are first compiled to Java source files. It can map the final line numbers in the bytecode to other line numbers in one or multiple source files.

On the other hand, Mixin keeps all original line numbers from the Mixins that are applied to the target class. Therefore the line numbers in the final class are not unique, and cannot be mapped reliably to the original source.

### The solution
A solution would be to assign unique line numbers to all merged Mixin methods. However, this would make reading stack traces even harder than it already is. Right now you can use the line number to find the Mixin which is causing an exception.

A much easier solution is to encode a custom format in the `SourceDebugExtension` which is specific to Mixin. The [Java class file format specification](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.11) does not dictate a specific format for the attribute - it is possible to store any string in it. All tools I've checked verify if the string is a SMAP (using the `SMAP` prefix) before parsing it. It is also [exposed in raw form in Java's debugging interface (JDI)](https://docs.oracle.com/javase/8/docs/jdk/api/jpda/jdi/com/sun/jdi/ReferenceType.html#sourceDebugExtension--), so we can parse it in the debugger to provide Mixin debugging.

In general, the only thing the debugger needs to know is the Mixin the method in the target class was merged from. I've used a very simple format to encode the metadata in the attribute:

```
MIXIN
com.example.mixin.MixinExample run()V handler$onRun$zza000(Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V
com.example.mixin.MixinExtra runExtra()V
```

The `MIXIN` prefix allows us to detect encoded data as Mixin source debug extension - this is very similar to the solution in the SMAP format which uses the `SMAP` indentifier.

### The implementation
I've added a new Mixin option `-Dmixin.sourceDebugExtension` which can be used to enable the generation of the attribute. I decided to disable it by default to prevent potential problems with other tools that are using the same attribute. In most cases there is no need to generate it because it is only usable by extending the IDE debugger to parse the additional metadata.

The metadata is generated by parsing all `@MixinMerged` annotations after all Mixins have been applied. I'm quite sure there are better ways to implement it, but that seemed like the easiest solution to me.

### IDE implementation
I've implemented debugging support for the IntelliJ IDEA plugin [MinecraftDev](https://github.com/minecraft-dev/MinecraftDev). It parses the additional metadata and uses it to jump to the correct source of the method. It will also redirect breakpoints to the target class so it will properly pause the execution at runtime.

See https://github.com/minecraft-dev/MinecraftDev/pull/115 for some screenshots of the Mixin debugging.