### PR TITLE
Fix minecraft 1.12 support

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.helpers.Booleans;
 import org.spongepowered.asm.launch.Blackboard;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.lib.Opcodes;
@@ -520,7 +519,7 @@ public final class MixinEnvironment implements ITokenProvider {
         }
         
         private boolean getLocalBooleanValue(boolean defaultValue) {
-            return Booleans.parseBoolean(System.getProperty(this.property), defaultValue);
+            return Boolean.parseBoolean(System.getProperty(this.property, Boolean.toString(defaultValue)));
         }
         
         private boolean getInheritedBooleanValue() {


### PR DESCRIPTION
`org.apache.logging.log4j.core.helpers.Booleans` was removed in newer versions of log4j and isnt present in log4j `2.8.1` used by minecraft 1.12.

This PR fixes support for minecraft 1.12 without breaking support for older versions.

Not sure what else to write here, so let me know of any questions you have.