### PR TITLE
Fix incorrect reference to InjectionError

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -427,7 +427,7 @@ public class CallbackInjector extends Injector {
                     switch (this.localCapture) {
                         case CAPTURE_FAILEXCEPTION:
                             Injector.logger.error("Injection error: {}", message);
-                            callbackMethod = this.generateErrorMethod(callback, "org/spongepowered/asm/mixin/injection/InjectionError", message);
+                            callbackMethod = this.generateErrorMethod(callback, "org/spongepowered/asm/mixin/injection/throwables/InjectionError", message);
                             break;
                         case CAPTURE_FAILSOFT:
                             Injector.logger.warn("Injection warning: {}", message);


### PR DESCRIPTION
This PR resolves a `NoClassDefError` caused by an incorrect reference to the `InjectionError` class, which was relocated in 0.5.6.