### PR TITLE
Fix issues with detecting FMLRelaunchLog message for INIT phase

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -743,11 +743,29 @@ public final class MixinEnvironment implements ITokenProvider {
     static class MixinLogger {
 
         static MixinAppender appender = new MixinAppender("MixinLogger", null, null);
+        static Level oldLevel = null;
 
         public MixinLogger() {
+            /*
+             * In order to determine when to switch to the INIT phase, Mixin
+             * relies on being able to detect a specific message
+             * ("Validating minecraft") logged to FMLRelaunchLog.
+             * However, this message is logged at the DEBUG level, which may
+             * not be enabled depending on the launcher or game version.
+             *
+             * To ensure that Mixin is always able to detect this message,
+             * we temporarily set the log level of FMLRelaunchLog to 'ALL'.
+             * To minimize the overall impact, the log level is restored
+             * (unless it was changed in the meantime) once MixinAppender
+             * detects the message.
+             */
             org.apache.logging.log4j.core.Logger log = (org.apache.logging.log4j.core.Logger)LogManager.getLogger("FML");
+            oldLevel = log.getLevel();
+
             appender.start();
             log.addAppender(appender);
+
+            log.setLevel(Level.ALL);
         }
 
         /**
@@ -764,6 +782,13 @@ public final class MixinEnvironment implements ITokenProvider {
                 if (event.getLevel() == Level.DEBUG && "Validating minecraft".equals(event.getMessage().getFormat())) {
                     // transition to INIT
                     MixinEnvironment.gotoPhase(Phase.INIT);
+
+                    // Only reset the log level if it's still ALL.
+                    // If something else changed the log level after we did, we don't want overwrite that change
+                    org.apache.logging.log4j.core.Logger log = (org.apache.logging.log4j.core.Logger)LogManager.getLogger("FML");
+                    if (log.getLevel() == Level.ALL) {
+                        log.setLevel(oldLevel);
+                    }
                 }
             }
             

--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -760,10 +760,10 @@ public final class MixinEnvironment implements ITokenProvider {
              * detects the message.
              */
             org.apache.logging.log4j.core.Logger log = (org.apache.logging.log4j.core.Logger)LogManager.getLogger("FML");
-            oldLevel = log.getLevel();
+            MixinLogger.oldLevel = log.getLevel();
 
-            appender.start();
-            log.addAppender(appender);
+            MixinLogger.appender.start();
+            log.addAppender(MixinLogger.appender);
 
             log.setLevel(Level.ALL);
         }
@@ -787,7 +787,7 @@ public final class MixinEnvironment implements ITokenProvider {
                     // If something else changed the log level after we did, we don't want overwrite that change
                     org.apache.logging.log4j.core.Logger log = (org.apache.logging.log4j.core.Logger)LogManager.getLogger("FML");
                     if (log.getLevel() == Level.ALL) {
-                        log.setLevel(oldLevel);
+                        log.setLevel(MixinLogger.oldLevel);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -779,7 +779,7 @@ public final class MixinEnvironment implements ITokenProvider {
 
             @Override
             public void append(LogEvent event) {
-                if (event.getLevel() == Level.DEBUG && "Validating minecraft".equals(event.getMessage().getFormat())) {
+                if (event.getLevel() == Level.DEBUG && "Validating minecraft".equals(event.getMessage().getFormattedMessage())) {
                     // transition to INIT
                     MixinEnvironment.gotoPhase(Phase.INIT);
 


### PR DESCRIPTION
Under certain launchers, such as Mojang's new in-beta launcher, the
log level for FMLRelaunchLog may end up being below DEBUG. To ensure
that Mixin is always able to detect the 'Validating minecraft' log
message, FMLRelaunchLog's level is set to DEBUG after MixinAppender is
added, and restored to its original value once the message is detected.

This resolves https://github.com/SpongePowered/SpongeForge/issues/1654