### PR TITLE
Support injecting into and overwriting constructors

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
@@ -107,10 +107,10 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
             
             if (elem.getKind() == ElementKind.FIELD) {
                 this.mixins.registerShadow((TypeElement)parent, (VariableElement)elem, shadow);
-            } else if (elem.getKind() == ElementKind.METHOD) {
+            } else if (elem.getKind() == ElementKind.METHOD || elem.getKind() == ElementKind.CONSTRUCTOR) {
                 this.mixins.registerShadow((TypeElement)parent, (ExecutableElement)elem, shadow);
             } else {
-                this.mixins.printMessage(Kind.ERROR, "Element is not a method or field",  elem);
+                this.mixins.printMessage(Kind.ERROR, "Element is not a method, constructor or field",  elem);
             }
         }
     }
@@ -127,10 +127,10 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
                 continue;
             }
             
-            if (elem.getKind() == ElementKind.METHOD) {
+            if (elem.getKind() == ElementKind.METHOD || elem.getKind() == ElementKind.CONSTRUCTOR) {
                 this.mixins.registerOverwrite((TypeElement)parent, (ExecutableElement)elem);
             } else {
-                this.mixins.printMessage(Kind.ERROR, "Element is not a method",  elem);
+                this.mixins.printMessage(Kind.ERROR, "Element is not a method or constructor",  elem);
             }
         }
     }

--- a/src/main/java/org/spongepowered/asm/mixin/Copy.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Copy.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Annotation used to indicate that a constructor should be copied to the
+ * target class.</p>
+ * 
+ * <p>The default behaviour of mixin classes when merging mixin methods is to
+ * not copy any constructors that are not annotated with {@link Overwrite}. This
+ * annotation can be used to override that behaviour and copy a constructor to
+ * the target class.</p>
+ */
+@Target({ ElementType.CONSTRUCTOR })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Copy {
+
+}

--- a/src/main/java/org/spongepowered/asm/mixin/Overwrite.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Overwrite.java
@@ -49,7 +49,7 @@ import org.spongepowered.asm.util.ConstraintParser.Constraint;
  * overwrite a member in the target class, and should be added to the
  * obfuscation table if {@link #remap} is true.</p>
  */
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Overwrite {
     

--- a/src/main/java/org/spongepowered/asm/mixin/Shadow.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Shadow.java
@@ -35,7 +35,7 @@ import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
  * Used to indicate a Mixin class member which is acting as a placeholder for a
  * method or field in the target class 
  */
-@Target({ ElementType.METHOD, ElementType.FIELD })
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Shadow {
 

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/InvokeInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/InvokeInjector.java
@@ -104,7 +104,7 @@ public abstract class InvokeInjector extends Injector {
      */
     protected void checkTargetForNode(Target target, InjectionNode node) {
         if (target.isCtor) {
-            MethodInsnNode superCall = target.findSuperInitNode();
+            MethodInsnNode superCall = target.findSuperOrThisInitNode();
             int superCallIndex = target.indexOf(superCall);
             int targetIndex = target.indexOf(node.getCurrentTarget());
             if (targetIndex <= superCallIndex) {
@@ -129,6 +129,7 @@ public abstract class InvokeInjector extends Injector {
                     + " in " + this);
         }
         
+        this.checkTargetForNode(target, node);
         this.injectAtInvoke(target, node);
     }
     

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
@@ -94,12 +94,6 @@ public class ModifyArgInjector extends InvokeInjector {
         }
     }
     
-    @Override
-    protected void inject(Target target, InjectionNode node) {
-        this.checkTargetForNode(target, node);
-        super.inject(target, node);
-    }
-    
     /**
      * Do the injection
      */

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgsInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgsInjector.java
@@ -62,12 +62,6 @@ public class ModifyArgsInjector extends InvokeInjector {
     protected void checkTarget(Target target) {
         this.checkTargetModifiers(target, false);
     }
-    
-    @Override
-    protected void inject(Target target, InjectionNode node) {
-        this.checkTargetForNode(target, node);
-        super.inject(target, node);
-    }
 
     /**
      * Do the injection

--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/Target.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/Target.java
@@ -490,18 +490,20 @@ public class Target implements Comparable<Target>, Iterable<AbstractInsnNode> {
     }
     
     /**
-     * Find the call to <tt>super()</tt> in a constructor. This attempts to
-     * locate the first call to <tt>&lt;init&gt;</tt> which isn't an inline call
-     * to another object ctor being passed into the super invocation.
+     * Find the call to <tt>super()</tt> or <tt>this()</tt> in a constructor.
+     * This attempts to locate the first call to <tt>&lt;init&gt;</tt> which
+     * isn't an inline call to another object ctor being passed into the
+     * super invocation.
      * 
-     * @return Call to <tt>super()</tt> or <tt>null</tt> if not found
+     * @return Call to <tt>super()</tt> or <tt>this()</tt>, or <tt>null</tt>
+     * if not found.
      */
-    public MethodInsnNode findSuperInitNode() {
+    public MethodInsnNode findSuperOrThisInitNode() {
         if (!this.isCtor) {
             return null;
         }
 
-        return Bytecode.findSuperInit(this.method, ClassInfo.forName(this.classNode.name).getSuperName());
+        return Bytecode.findSuperOrThisInit(this.method, this.classNode.name, ClassInfo.forName(this.classNode.name).getSuperName());
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassContext.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.lib.tree.MethodInsnNode;
 import org.spongepowered.asm.lib.tree.MethodNode;
 import org.spongepowered.asm.mixin.struct.MemberRef;
 import org.spongepowered.asm.mixin.transformer.ClassInfo.Method;
+import org.spongepowered.asm.util.Constants;
 
 /**
  * Base for class context objects
@@ -107,7 +108,7 @@ abstract class ClassContext {
     }
 
     protected void upgradeMethodRef(MethodNode containingMethod, MemberRef methodRef, Method method) {
-        if (methodRef.getOpcode() != Opcodes.INVOKESPECIAL) {
+        if (methodRef.getOpcode() != Opcodes.INVOKESPECIAL || Constants.CTOR.equals(methodRef.getName())) {
             return;
         }
         

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -772,9 +772,7 @@ public final class ClassInfo {
     }
 
     private void addMethod(MethodNode method, boolean injected) {
-        if (!method.name.startsWith("<")) {
-            this.methods.add(new Method(method, injected));
-        }
+        this.methods.add(new Method(method, injected));
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -391,8 +391,8 @@ class MixinPreProcessorStandard {
             mixinMethod.name = method.renameTo(target.name);
         }
         
-        if (Constants.CTOR.equals(target.name)) {
-            throw new InvalidMixinException(this.mixin, String.format("Nice try! %s in %s cannot alias a constructor", mixinMethod.name, this.mixin));
+        if (Constants.CTOR.equals(target.name) && !Constants.CTOR.equals(mixinMethod.name)) {
+            throw new InvalidMixinException(this.mixin, String.format("%s in %s cannot alias a constructor", mixinMethod.name, this.mixin));
         }
         
         if (!Bytecode.compareFlags(mixinMethod, target, Opcodes.ACC_STATIC)) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -50,6 +50,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.gen.AccessorInfo;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 import org.spongepowered.asm.mixin.injection.struct.InjectorGroupInfo;
@@ -539,7 +540,14 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
             methodRef.setDesc(this.transformMethodDescriptor(methodRef.getDesc()));
         } else if (this.detachedSuper || this.inheritsFromMixin) {
             if (methodRef.getOpcode() == Opcodes.INVOKESPECIAL) {
-                this.updateStaticBinding(method, methodRef);
+                if (Constants.CTOR.equals(methodRef.getName())) {
+                    if (methodRef.getOwner().equals(mixin.getClassInfo().getSuperName()) &&
+                        this.mixin.getClassInfo().getSuperClass().isMixin()) {
+                        this.updateStaticBinding(method, methodRef);
+                    }
+                } else {
+                    this.updateStaticBinding(method, methodRef);
+                }
             } else if (methodRef.getOpcode() == Opcodes.INVOKEVIRTUAL && ClassInfo.forName(methodRef.getOwner()).isMixin()) {
                 this.updateDynamicBinding(method, methodRef);
             }

--- a/src/main/java/org/spongepowered/asm/util/Bytecode.java
+++ b/src/main/java/org/spongepowered/asm/util/Bytecode.java
@@ -253,15 +253,15 @@ public final class Bytecode {
     }
 
     /**
-     * Find the call to <tt>super()</tt> in a constructor. This attempts to
-     * locate the first call to <tt>&lt;init&gt;</tt> which isn't an inline call
-     * to another object ctor being passed into the super invocation.
+     * Find the call to <tt>super()</tt> or <tt>this()</tt> in a constructor. This
+     * attempts to locate the first call to <tt>&lt;init&gt;</tt> which isn't an
+     * inline call to another object ctor being passed into the super invocation.
      * 
      * @param method ctor to scan
      * @param superName name of superclass
-     * @return Call to <tt>super()</tt> or <tt>null</tt> if not found
+     * @return Call to <tt>super()</tt> or <tt>this()</tt>, or <tt>null</tt> if not found
      */
-    public static MethodInsnNode findSuperInit(MethodNode method, String superName) {
+    public static MethodInsnNode findSuperOrThisInit(MethodNode method, String className, String superName) {
         if (!Constants.CTOR.equals(method.name)) {
             return null;
         }
@@ -276,7 +276,7 @@ public final class Bytecode {
                 if (Constants.CTOR.equals(methodNode.name)) {
                     if (news > 0) {
                         news--;
-                    } else if (methodNode.owner.equals(superName)) {
+                    } else if (methodNode.owner.equals(className) || methodNode.owner.equals(superName)) {
                         return methodNode;
                     }
                 }


### PR DESCRIPTION
Yes, it is *sometimes* possible to do the same with 1, 2, 3, or even 10 redirects and a few temporary static ThreadLocal fields to share data between redirects (and finally an inject at return to clear those temporary fields and avoid leaking memory), but a single overwrite/inject is much cleaner. Also, redirects may simply not work when you need to access fields in `this` and there just aren't any method calls including `this` that you can redirect.

This pull request implements injecting into, overwriting, and copying constructors safely, meaning that it is impossible to write a mixin that will generate java bytecode for which there is no equivalent source code. It also fixes two bugs in Mixin related to constructors:

 - Mixin makes sure an injection (such as ModifyArgs) before a call to `super()` is static, but is static, but doesn't make sure an injection before `this()` is static
 - Mixin appends field initializers to constructors that call `this()` rather than `super()`, causing the fields to be initialized twice

## How it works

 - `@Overwrite` can be applied to constructors
 - `@Copy` can be used to copy a constructor to the target class, without necessarily overwriting an existing one
 - `@Inject` can target constructors at any injection point, not just `RETURN`
 - `@Shadow` can shadow a constructor

Here is how my pull request enforces the various restrictions that constructors have:

#### A constructor needs to call either a `this()` constructor or a `super()` constructor
 - Injections before the call to the other constructor can't be cancelled
 - A constructor can only be overwritten by another constructor
 - Overwrites must contain either a call to a `@Shadow`ed/`@Copy`ed `this()` or `super()` constructor. If it's a super constructor, then the mixin must extend the target's superclass, or a mixin that is targetting it and shadows the super constructor. Inheriting another mixin not targetting the superclass can still be done, but with another "intermediate" mixin in between which shadows the super constructors.

#### `this` can't be accessed before calling `this()` or `super()`
 - Injections before the call to the other constructor must be static
 - For overwrites, the Java compiler already enforces this restriction

#### Final fields can't be set twice
 - `@Final` fields can't be set, as usual
 - `@Shadow`ed `final` (not `@Final`) fields can be set from a constructor only

#### All final fields must be set

This is not enforced, but leaving final fields uninitialized does not cause any problems apparently. They are just initialized to their default value of null/0/false. The compiler error seems to be just for convenience, since leaving a final field uninitialized is useless.

#### Field initializers

Field initializers are copied to every constructor in the target class or mixed in by another mixin.

Of course, I might have overlooked or accidentally broken something since I'm not the author of Mixin, but I'd be happy to fix any problems and work to get this pull request merged, increasing Mixin's power without reducing its safety.