### PR TITLE
fix minor bug in BeforeInvoke.find logic

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/points/BeforeInvoke.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/points/BeforeInvoke.java
@@ -158,13 +158,15 @@ public class BeforeInvoke extends InjectionPoint {
         this.log("{} is searching for an injection point in method with descriptor {}", this.className, desc);
         
         boolean hasDescriptor = this.target instanceof ITargetSelectorByName && ((ITargetSelectorByName)this.target).getDesc() == null;
-        
-        if (!this.find(desc, insns, nodes, this.target, SearchType.STRICT) && hasDescriptor && this.allowPermissive) {
+        boolean found = this.find(desc, insns, nodes, this.target, SearchType.STRICT);
+
+        if (!found && hasDescriptor && this.allowPermissive) {
             this.logger.warn("STRICT match for {} using \"{}\" in {} returned 0 results, attempting permissive search. "
                     + "To inhibit permissive search set mixin.env.allowPermissiveMatch=false", this.className, this.target, this.context);
-            return this.find(desc, insns, nodes, this.target, SearchType.PERMISSIVE);
+            found = this.find(desc, insns, nodes, this.target, SearchType.PERMISSIVE);
         }
-        return true;
+
+        return found;
     }
 
     protected boolean find(String desc, InsnList insns, Collection<AbstractInsnNode> nodes, ITargetSelector selector, SearchType searchType) {


### PR DESCRIPTION
Looking at the commit history before the addition of a permissive mode, as well as the Javadoc, it seems to me that this is the correct way to implement this logic - in the unfixed variant, a STRICT-mode search will always return true if the "permissive" code path is not executed, even if no injection point was found.
