### PR TITLE
Add InstanceOf Injection Point and Redirect

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/At.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/At.java
@@ -101,8 +101,9 @@ public @interface At {
      * {@link BeforeFieldAccess FIELD},
      * {@link BeforeNew NEW},
      * {@link BeforeStringInvoke INVOKE_STRING},
-     * {@link JumpInsnPoint JUMP} and
-     * {@link BeforeConstant CONSTANT}.
+     * {@link JumpInsnPoint JUMP},
+     * {@link BeforeConstant CONSTANT}, and
+     * {@link InstanceofInsnPoint INSTANCEOF}.
      * See the javadoc for each type for more details on the scheme used by each
      * injection point.</p>
      * 

--- a/src/main/java/org/spongepowered/asm/mixin/injection/ModifyIf.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/ModifyIf.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.injection;
+
+import org.spongepowered.asm.mixin.MixinEnvironment.Option;
+import org.spongepowered.asm.mixin.injection.points.BeforeFieldAccess;
+import org.spongepowered.asm.mixin.injection.throwables.InjectionError;
+import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
+import org.spongepowered.asm.util.ConstraintParser.Constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModifyIf {
+    
+
+    String method();
+
+    At at();
+
+
+
+
+
+}

--- a/src/main/java/org/spongepowered/asm/mixin/injection/points/InstanceofInsnPoint.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/points/InstanceofInsnPoint.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.injection.points;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.InjectionPoint.AtCode;
+import org.spongepowered.asm.mixin.injection.struct.InjectionPointData;
+
+import java.util.Collection;
+import java.util.ListIterator;
+
+/**
+ * <p>This injection point searches for JUMP opcodes (if, try/catch, continue,
+ * break, conditional assignment, etc.) with either a particular opcode or at a
+ * particular ordinal in the method body (eg. "the Nth JUMP insn" where N is the
+ * ordinal of the instruction). By default it returns all JUMP instructions in a
+ * method body. It accepts the following parameters from
+ * {@link org.spongepowered.asm.mixin.injection.At At}:</p>
+ * 
+ * <dl>
+ *   <dt>opcode</dt>
+ *   <dd>The {@link Opcodes opcode} of the jump instruction, must be one of
+ *   IFEQ, IFNE, IFLT, IFGE, IFGT, IFLE, IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT,
+ *   IF_ICMPGE, IF_ICMPGT, IF_ICMPLE, IF_ACMPEQ, IF_ACMPNE, GOTO, JSR, IFNULL or
+ *   IFNONNULL. Defaults to <b>-1</b> which matches any JUMP opcode.
+ *   </dd>
+ *   <dt>ordinal</dt>
+ *   <dd>The ordinal position of the jump insn to match. For example if there
+ *   are 3 jumps of the specified type and you want to match the 2nd then you
+ *   can specify an <em>ordinal</em> of <b>1</b> (ordinals are zero-indexed).
+ *   The default value is <b>-1</b> which supresses ordinal matching</dd>
+ * </dl>
+ * 
+ * <p>Example:</p>
+ * <blockquote><pre>
+ *   &#064;At(value = "INSTANCEOF", args="classValue=net/minecraft/entity/Entity", ordinal = 2)</pre>
+ * </blockquote>
+ * 
+ * <p>Note that like all standard injection points, this class matches the insn
+ * itself, putting the injection point immediately <em>before</em> the access in
+ * question. Use {@link org.spongepowered.asm.mixin.injection.At#shift shift}
+ * specifier to adjust the matched opcode as necessary.</p>
+ */
+@AtCode("INSTANCEOF")
+public class InstanceofInsnPoint extends InjectionPoint {
+
+    private final String targetClass;
+
+    private final int ordinal;
+
+    public InstanceofInsnPoint(InjectionPointData data) {
+        this.targetClass = data.get("classValue", "all");
+        this.ordinal = data.getOrdinal();
+    }
+
+    @Override
+    public boolean find(String desc, InsnList insns, Collection<AbstractInsnNode> nodes) {
+        boolean found = false;
+        int ordinal = 0;
+
+        ListIterator<AbstractInsnNode> iter = insns.iterator();
+        while (iter.hasNext()) {
+            AbstractInsnNode insn = iter.next();
+
+            if (insn instanceof TypeInsnNode
+                && (insn.getOpcode() == Opcodes.INSTANCEOF)
+                && (this.targetClass.equalsIgnoreCase("all")
+                    || this.targetClass.equalsIgnoreCase(((TypeInsnNode) insn).desc))) {
+                if (this.ordinal == -1 || this.ordinal == ordinal) {
+                    nodes.add(insn);
+                    found = true;
+                }
+
+                ordinal++;
+            }
+        }
+
+        return found;
+    }
+}


### PR DESCRIPTION
In a classic case of "I see the bits of things I want to change, but Mixin doesn't have a way to do that without an overwrite or cancellable injection or some weird hackery with redirects in an earlier method etc." I spoke about the possibility of redirecting an `instanceof` opcode since it's simply just the same as an `invokevirtual` with some specific type arguments, and some if statements end up having only an `instanceof` check within a deeply nested method body that otherwise is difficult to modify. 

The key with this is to expose two things:
- **`INSTANCEOF`** as an injection point
- Adding to `@Redirect`'s scope with injection points to redirect instanceof checks

Because we can establish that an `instanceof` takes two arguments, an object, and a class literal, we know that we cannot explicitly return the class literal, because in bytecode, it doesn't use a class string, it uses a class literal. So, we instead, pass the object argument, and force return a `boolean` value, thereby replacing the `instanceof` entirely with now a method.

What this will look like:

Target
```java
public void foo(Bar bar) {
  if (bar instanceof Baz) {
    ((Baz) bar).doFooBarBaz();
  }
}
```
Mixin
```
@Redirect(method = "foo", at = @At(value = "INSTANCEOF", args = "classValue=com.myexample.Baz"))
private boolean redirectBaz(Bar bar) {
  // do something here, but remember, still might need to check the instanceof!
}
```