### PR TITLE
Fix `@Mutable` to work on private final fields

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -464,8 +464,8 @@ class MixinApplicatorStandard {
             if (target != null) {
                 Annotations.merge(shadow, target);
                 
-                // Strip the FINAL flag from @Mutable non-private fields
-                if (entry.getValue().isDecoratedMutable() && !Bytecode.hasFlag(target, Opcodes.ACC_PRIVATE)) {
+                // Strip the FINAL flag from @Mutable fields
+                if (entry.getValue().isDecoratedMutable()) {
                     target.access &= ~Opcodes.ACC_FINAL;
                 }
             }


### PR DESCRIPTION
Removes the final flag from fields targeted by `@Mutable`. This is required to target newer Java versions.