### PR TITLE
Fix improper description of mixin functionality

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
@@ -42,7 +42,7 @@ import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerAccessor.
 import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerAccessor.AnnotatedElementInvoker;
 import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerInjector.AnnotatedElementInjectionPoint;
 import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerInjector.AnnotatedElementInjector;
-import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerOverwrite.AnnotatedElementOverwrite;
+import org.spongepowered.tools.obfuscation.AnnotatedMixinElementHandlerNuke.AnnotatedElementNuke;
 import org.spongepowered.tools.obfuscation.interfaces.IMessagerSuppressible;
 import org.spongepowered.tools.obfuscation.interfaces.IMixinAnnotationProcessor;
 import org.spongepowered.tools.obfuscation.interfaces.IMixinValidator;
@@ -129,9 +129,9 @@ class AnnotatedMixin {
     private final boolean virtual;
 
     /**
-     * Overwrite handler
+     * Nuke handler
      */
-    private final AnnotatedMixinElementHandlerOverwrite overwrites;
+    private final AnnotatedMixinElementHandlerNuke nukings;
 
     /**
      * Shadow handler
@@ -172,7 +172,7 @@ class AnnotatedMixin {
         this.primaryTarget = this.initTargets();
         this.remap = this.annotation.getBoolean("remap", true) && this.targets.size() > 0;
 
-        this.overwrites = new AnnotatedMixinElementHandlerOverwrite(ap, this);
+        this.nukings = new AnnotatedMixinElementHandlerNuke(ap, this);
         this.shadows = new AnnotatedMixinElementHandlerShadow(ap, this);
         this.injectors = new AnnotatedMixinElementHandlerInjector(ap, this);
         this.accessors = new AnnotatedMixinElementHandlerAccessor(ap, this);
@@ -345,13 +345,13 @@ class AnnotatedMixin {
 
     private void runFinalValidation() {
         for (ExecutableElement method : this.methods) {
-            this.overwrites.registerMerge(method);
+            this.nukings.registerMerge(method);
         }
     }
 
-    public void registerOverwrite(ExecutableElement method, AnnotationHandle overwrite, boolean shouldRemap) {
+    public void registerNuke(ExecutableElement method, AnnotationHandle nuke, boolean shouldRemap) {
         this.methods.remove(method);
-        this.overwrites.registerOverwrite(new AnnotatedElementOverwrite(method, overwrite, shouldRemap));
+        this.nukings.registerNuke(new AnnotatedElementNuke(method, nuke, shouldRemap));
     }
 
     public void registerShadow(VariableElement field, AnnotationHandle shadow, boolean shouldRemap) {

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandler.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandler.java
@@ -396,7 +396,7 @@ abstract class AnnotatedMixinElementHandler {
      * warnings where appropriate
      */
     protected final void validateTargetMethod(ExecutableElement method, AnnotationHandle annotation, AliasedElementName name, String type,
-            boolean overwrite, boolean merge) {
+            boolean nuke, boolean merge) {
         String signature = TypeUtils.getJavaSignature(method);
 
         for (TypeHandle target : this.mixin.getTargets()) {
@@ -422,7 +422,7 @@ abstract class AnnotatedMixinElementHandler {
             }
             
             if (targetMethod != null) {
-                if (overwrite) {
+                if (nuke) {
                     this.validateMethodVisibility(method, annotation, type, target, targetMethod);
                 }
             } else if (!merge) {

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerNuke.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerNuke.java
@@ -37,18 +37,18 @@ import org.spongepowered.tools.obfuscation.mirror.AnnotationHandle;
 import org.spongepowered.tools.obfuscation.mirror.TypeHandle;
 
 /**
- * A module for {@link AnnotatedMixin} which handles method overwrites
+ * A module for {@link AnnotatedMixin} which handles method nukes
  */
-class AnnotatedMixinElementHandlerOverwrite extends AnnotatedMixinElementHandler {
+class AnnotatedMixinElementHandlerNuke extends AnnotatedMixinElementHandler {
     
     /**
-     * Overwrite element
+     * Nuke element
      */
-    static class AnnotatedElementOverwrite extends AnnotatedElement<ExecutableElement> {
+    static class AnnotatedElementNuke extends AnnotatedElement<ExecutableElement> {
         
         private final boolean shouldRemap;
         
-        public AnnotatedElementOverwrite(ExecutableElement element, AnnotationHandle annotation, boolean shouldRemap) {
+        public AnnotatedElementNuke(ExecutableElement element, AnnotationHandle annotation, boolean shouldRemap) {
             super(element, annotation);
             this.shouldRemap = shouldRemap;
         }
@@ -59,48 +59,48 @@ class AnnotatedMixinElementHandlerOverwrite extends AnnotatedMixinElementHandler
 
     }
     
-    AnnotatedMixinElementHandlerOverwrite(IMixinAnnotationProcessor ap, AnnotatedMixin mixin) {
+    AnnotatedMixinElementHandlerNuke(IMixinAnnotationProcessor ap, AnnotatedMixin mixin) {
         super(ap, mixin);
     }
 
     public void registerMerge(ExecutableElement method) {
-        this.validateTargetMethod(method, null, new AliasedElementName(method, AnnotationHandle.MISSING), "overwrite", true, true);
+        this.validateTargetMethod(method, null, new AliasedElementName(method, AnnotationHandle.MISSING), "nuke", true, true);
     }
 
-    public void registerOverwrite(AnnotatedElementOverwrite elem) {
+    public void registerNuke(AnnotatedElementNuke elem) {
         AliasedElementName name = new AliasedElementName(elem.getElement(), elem.getAnnotation());
-        this.validateTargetMethod(elem.getElement(), elem.getAnnotation(), name, "@Overwrite", true, false);
+        this.validateTargetMethod(elem.getElement(), elem.getAnnotation(), name, "@Nuke", true, false);
         this.checkConstraints(elem.getElement(), elem.getAnnotation());
         
         if (elem.shouldRemap()) {
             for (TypeHandle target : this.mixin.getTargets()) {
-                if (!this.registerOverwriteForTarget(elem, target)) {
+                if (!this.registerNukeForTarget(elem, target)) {
                     return;
                 }
             }
         }
         
-        if (!"true".equalsIgnoreCase(this.ap.getOption(SupportedOptions.DISABLE_OVERWRITE_CHECKER))) {
-            Kind overwriteErrorKind = "error".equalsIgnoreCase(this.ap.getOption(SupportedOptions.OVERWRITE_ERROR_LEVEL))
+        if (!"true".equalsIgnoreCase(this.ap.getOption(SupportedOptions.DISABLE_NUKE_CHECKER))) {
+            Kind nukeErrorKind = "error".equalsIgnoreCase(this.ap.getOption(SupportedOptions.NUKE_ERROR_LEVEL))
                     ? Kind.ERROR : Kind.WARNING;
             
             String javadoc = this.ap.getJavadocProvider().getJavadoc(elem.getElement());
             if (javadoc == null) {
-                this.ap.printMessage(overwriteErrorKind, "@Overwrite is missing javadoc comment", elem.getElement(), SuppressedBy.OVERWRITE);
+                this.ap.printMessage(nukeErrorKind, "@Nuke is missing javadoc comment", elem.getElement(), SuppressedBy.NUKE);
                 return;
             }
             
             if (!javadoc.toLowerCase(Locale.ROOT).contains("@author")) {
-                this.ap.printMessage(overwriteErrorKind, "@Overwrite is missing an @author tag", elem.getElement(), SuppressedBy.OVERWRITE);
+                this.ap.printMessage(nukeErrorKind, "@Nuke is missing an @author tag", elem.getElement(), SuppressedBy.NUKE);
             }
             
             if (!javadoc.toLowerCase(Locale.ROOT).contains("@reason")) {
-                this.ap.printMessage(overwriteErrorKind, "@Overwrite is missing an @reason tag", elem.getElement(), SuppressedBy.OVERWRITE);
+                this.ap.printMessage(nukeErrorKind, "@Nuke is missing an @reason tag", elem.getElement(), SuppressedBy.NUKE);
             }
         }
     }
 
-    private boolean registerOverwriteForTarget(AnnotatedElementOverwrite elem, TypeHandle target) {
+    private boolean registerNukeForTarget(AnnotatedElementNuke elem, TypeHandle target) {
         MappingMethod targetMethod = target.getMappingMethod(elem.getSimpleName(), elem.getDesc());
         ObfuscationData<MappingMethod> obfData = this.obf.getDataProvider().getObfMethod(targetMethod);
         
@@ -117,14 +117,14 @@ class AnnotatedMixinElementHandlerOverwrite extends AnnotatedMixinElementHandler
                 // well, we tried
             }
             
-            this.ap.printMessage(error, "No obfuscation mapping for @Overwrite method", elem.getElement());
+            this.ap.printMessage(error, "No obfuscation mapping for @Nuke method", elem.getElement());
             return false;
         }
 
         try {
             this.addMethodMappings(elem.getSimpleName(), elem.getDesc(), obfData);
         } catch (MappingConflictException ex) {
-            elem.printMessage(this.ap, Kind.ERROR, "Mapping conflict for @Overwrite method: " + ex.getNew().getSimpleName() + " for target " + target 
+            elem.printMessage(this.ap, Kind.ERROR, "Mapping conflict for @Nuke method: " + ex.getNew().getSimpleName() + " for target " + target
                     + " conflicts with existing mapping " + ex.getOld().getSimpleName());
             return false;
         }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
@@ -55,7 +55,7 @@ import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
 import org.spongepowered.asm.launch.MixinBootstrap;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.util.ITokenProvider;
@@ -427,20 +427,20 @@ final class AnnotatedMixins implements IMixinAnnotationProcessor, ITokenProvider
     }
 
     /**
-     * Register an {@link org.spongepowered.asm.mixin.Overwrite} method
+     * Register an {@link Nuke} method
      *
      * @param mixinType Mixin class
-     * @param method Overwrite method
+     * @param method Nuke method
      */
-    public void registerOverwrite(TypeElement mixinType, ExecutableElement method) {
+    public void registerNuke(TypeElement mixinType, ExecutableElement method) {
         AnnotatedMixin mixinClass = this.getMixin(mixinType);
         if (mixinClass == null) {
-            this.printMessage(Kind.ERROR, "Found @Overwrite annotation on a non-mixin method", method);
+            this.printMessage(Kind.ERROR, "Found @Nuke annotation on a non-mixin method", method);
             return;
         }
 
-        AnnotationHandle overwrite = AnnotationHandle.of(method, Overwrite.class);
-        mixinClass.registerOverwrite(method, overwrite, AnnotatedMixins.shouldRemap(mixinClass, overwrite));
+        AnnotationHandle nuke = AnnotationHandle.of(method, Nuke.class);
+        mixinClass.registerNuke(method, nuke, AnnotatedMixins.shouldRemap(mixinClass, nuke));
     }
 
     /**

--- a/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
@@ -36,7 +36,7 @@ import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic.Kind;
 
 import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
@@ -44,13 +44,13 @@ import org.spongepowered.tools.obfuscation.mirror.AnnotationHandle;
 import org.spongepowered.tools.obfuscation.mirror.TypeUtils;
 
 /**
- * Annotation processor which finds {@link Shadow} and {@link Overwrite}
+ * Annotation processor which finds {@link Shadow} and {@link Nuke}
  * annotations in mixin classes and generates new obfuscation mappings
  */
 @SupportedAnnotationTypes({
     "org.spongepowered.asm.mixin.Mixin",
     "org.spongepowered.asm.mixin.Shadow",
-    "org.spongepowered.asm.mixin.Overwrite",
+    "org.spongepowered.asm.mixin.Nuke",
     "org.spongepowered.asm.mixin.gen.Accessor",
     "org.spongepowered.asm.mixin.Implements"
 })
@@ -70,7 +70,7 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
         
         this.processMixins(roundEnv);
         this.processShadows(roundEnv);
-        this.processOverwrites(roundEnv);
+        this.processNukings(roundEnv);
         this.processAccessors(roundEnv);
         this.processInvokers(roundEnv);
         this.processImplements(roundEnv);
@@ -116,11 +116,11 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
     }
 
     /**
-     * Searches for {@link Overwrite} annotations and registers them with their
+     * Searches for {@link Nuke} annotations and registers them with their
      * parent mixins
      */
-    private void processOverwrites(RoundEnvironment roundEnv) {
-        for (Element elem : roundEnv.getElementsAnnotatedWith(Overwrite.class)) {
+    private void processNukings(RoundEnvironment roundEnv) {
+        for (Element elem : roundEnv.getElementsAnnotatedWith(Nuke.class)) {
             Element parent = elem.getEnclosingElement();
             if (!(parent instanceof TypeElement)) {
                 this.mixins.printMessage(Kind.ERROR, "Unexpected parent with type " + TypeUtils.getElementType(parent), elem);
@@ -128,7 +128,7 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
             }
             
             if (elem.getKind() == ElementKind.METHOD) {
-                this.mixins.registerOverwrite((TypeElement)parent, (ExecutableElement)elem);
+                this.mixins.registerNuke((TypeElement)parent, (ExecutableElement)elem);
             } else {
                 this.mixins.printMessage(Kind.ERROR, "Element is not a method",  elem);
             }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationData.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationData.java
@@ -67,7 +67,7 @@ public class ObfuscationData<T> implements Iterable<ObfuscationType> {
     }
     
     /**
-     * Add an entry to the map, overwrites any previous entries. Since this
+     * Add an entry to the map, nukes any previous entries. Since this
      * method name poorly communicates its purpose, it is deprecated in favour
      * of {@link #put}.  
      * 

--- a/src/ap/java/org/spongepowered/tools/obfuscation/SupportedOptions.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/SupportedOptions.java
@@ -41,8 +41,8 @@ public final class SupportedOptions {
     public static final String OUT_REFMAP_FILE           = "outRefMapFile";
     public static final String DISABLE_TARGET_VALIDATOR  = "disableTargetValidator";
     public static final String DISABLE_TARGET_EXPORT     = "disableTargetExport";
-    public static final String DISABLE_OVERWRITE_CHECKER = "disableOverwriteChecker";
-    public static final String OVERWRITE_ERROR_LEVEL     = "overwriteErrorLevel";
+    public static final String DISABLE_NUKE_CHECKER      = "disableNukeChecker";
+    public static final String NUKE_ERROR_LEVEL          = "nukeErrorLevel";
     public static final String DEFAULT_OBFUSCATION_ENV   = "defaultObfuscationEnv";
     public static final String DEPENDENCY_TARGETS_FILE   = "dependencyTargetsFile";
     public static final String MAPPING_TYPES             = "mappingTypes";
@@ -60,8 +60,8 @@ public final class SupportedOptions {
             SupportedOptions.OUT_REFMAP_FILE,
             SupportedOptions.DISABLE_TARGET_VALIDATOR,
             SupportedOptions.DISABLE_TARGET_EXPORT,
-            SupportedOptions.DISABLE_OVERWRITE_CHECKER,
-            SupportedOptions.OVERWRITE_ERROR_LEVEL,
+            SupportedOptions.DISABLE_NUKE_CHECKER,
+            SupportedOptions.NUKE_ERROR_LEVEL,
             SupportedOptions.DEFAULT_OBFUSCATION_ENV,
             SupportedOptions.DEPENDENCY_TARGETS_FILE,
             SupportedOptions.MAPPING_TYPES,

--- a/src/ap/java/org/spongepowered/tools/obfuscation/SuppressedBy.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/SuppressedBy.java
@@ -37,7 +37,7 @@ public enum SuppressedBy {
     CONSTRAINTS("constraints"),
     
     /**
-     * Suppress warnings about overwrite visibility upgrading/downgrading target
+     * Suppress warnings about nuke visibility upgrading/downgrading target
      * visibility 
      */
     VISIBILITY("visibility"),
@@ -53,10 +53,10 @@ public enum SuppressedBy {
     MAPPING("mapping"),
     
     /**
-     * Suppress warnings for when an <tt>&#064;Overwrite</tt> method is missing
+     * Suppress warnings for when an <tt>&#064;Nuke</tt> method is missing
      * javadoc, or author or reason tags
      */
-    OVERWRITE("overwrite"),
+    NUKE("nuke"),
     
     /**
      * Suppress warnings when a mixin target specified by name is located in the

--- a/src/launchwrapper/java/org/spongepowered/asm/launch/platform/MixinPlatformAgentFMLLegacy.java
+++ b/src/launchwrapper/java/org/spongepowered/asm/launch/platform/MixinPlatformAgentFMLLegacy.java
@@ -539,7 +539,7 @@ public class MixinPlatformAgentFMLLegacy extends MixinPlatformAgentAbstract impl
 
             // Only reset the log level if it's still ALL. If something
             // else changed the log level after we did, we don't want
-            // overwrite that change. No null check is needed here
+            // nuke that change. No null check is needed here
             // because the appender will not be injected if the log is
             // null
             if (MixinPlatformAgentFMLLegacy.log.getLevel() == Level.ALL) {

--- a/src/main/java/org/spongepowered/asm/mixin/Dynamic.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Dynamic.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  * 
  * <ol>
  *   <li>Aids mixin maintainers by providing context for seemingly-pointless
- *     injections. An injector or overwrite whose target does not appear to
+ *     injections. An injector or nuking whose target does not appear to
  *     exist can be given context by decorating it with this annotation.</li>
  *   <li>Allowing mixin tooling such as IDE plugins to gain awareness that a
  *     particular target can be allowed to fail validation from static analysis.

--- a/src/main/java/org/spongepowered/asm/mixin/Final.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Final.java
@@ -47,7 +47,7 @@ import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
  *     {@link InvalidMixinException} is thrown.
  *   </li>
  *   <li>
- *     On an {@link Inject injector} or {@link Overwrite overwritten} method,
+ *     On an {@link Inject injector} or {@link Nuke nuke} method,
  *     it is equivalent to setting the priority of the containing mixin to
  *     {@link Integer#MAX_VALUE} but applies only to the annotated method. This
  *     allows methods to mark themselves as effectively final, preventing their

--- a/src/main/java/org/spongepowered/asm/mixin/Intrinsic.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Intrinsic.java
@@ -30,10 +30,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation allows fine-tuning of the overwrite policy for a
+ * This annotation allows fine-tuning of the nuke policy for a
  * soft-implemented interface member method.
  * 
- * <p>By default, all members within a mixin will overwrite (completely replace)
+ * <p>By default, all members within a mixin will nuke (completely replace)
  * matching methods in the target class without prejudice. However this can be
  * a problem when soft-implementing an interface to deal with a method conflict
  * because it may be desirable to only override the method <b>if it does not
@@ -92,7 +92,7 @@ import java.lang.annotation.Target;
  * }</pre></blockquote>
  * 
  * <p>Then we still have the original problem that the method becomes re-entrant
- * without specifying the additional Overwrite. We can solve this with the
+ * without specifying the additional Nuke. We can solve this with the
  * second {@link Intrinsic} behaviour, and set the {@link #displace} argument to
  * <code>true</code>. Setting <code>displace</code> instructs the mixin
  * transformer to <em>proxy</em> the method call <em>if</em> the target already
@@ -100,12 +100,12 @@ import java.lang.annotation.Target;
  * accessor to call the original method in all circumstances.</p>
  * 
  * <p>When <code>displace</code> is enabled, if the target method exists then
- * instead of being overwritten it is instead <em>renamed</em> with a temporary
+ * instead of being nuke it is instead <em>renamed</em> with a temporary
  * name and all references to the original method <em>within the Intrinsic
  * method</em> are updated to call the renamed method. This means that all
  * external code will still reference the Intrinsic accessor (just as it would
- * have done with a regular overwrite) but code <em>within</em> the Intrinsic
- * accessor will call the overwritten method.</p>
+ * have done with a regular nuke) but code <em>within</em> the Intrinsic
+ * accessor will call the nuked method.</p>
  * 
  * <blockquote><pre>&#064;Shadow public int getSomething();
  * 
@@ -123,7 +123,7 @@ public @interface Intrinsic {
      * If set to true, this intrinsic method will replace any existing method in
      * the target class by renaming it and updating internal references inside
      * the method to reference the displaced method. If false or omitted,
-     * instructs this intrinsic method to <b>not</b> overwrite the target method
+     * instructs this intrinsic method to <b>not</b> nuke the target method
      * if it exists, contrary to the normal behaviour for mixins
      * 
      * @return true if this intrinsic method should displace matching targets

--- a/src/main/java/org/spongepowered/asm/mixin/Nuke.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Nuke.java
@@ -32,29 +32,29 @@ import java.lang.annotation.Target;
 import org.spongepowered.asm.util.ConstraintParser.Constraint;
 
 /**
- * <p>Annotation used to indicate a mixin class member which must overwrite a
+ * <p>Annotation used to indicate a mixin class member which must nuke a
  * method in the target class.</p>
  * 
  * <p>The default behaviour of mixin classes when merging mixin methods is to
  * replace methods in the target class which already exist, and simply add any
  * other methods to the target class body as new members. This default behaviour
- * allows methods in the target class to be easily overwritten by simply
+ * allows methods in the target class to be easily nuked by simply
  * creating a method in the mixin with a signature matching the member to be
- * overwritten.</p>
+ * nuked.</p>
  * 
  * <p>This is not sufficient for obfuscated methods however, since as mixins
  * traverse the obfuscation boundary, this association with the target method is
- * lost because the method name will change. The {@link Overwrite} annotation is
+ * lost because the method name will change. The {@link Nuke} annotation is
  * used to indicate to the annotation processor that this method is intended to
- * overwrite a member in the target class, and should be added to the
+ * nuke a member in the target class, and should be added to the
  * obfuscation table if {@link #remap} is true.</p>
  */
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Overwrite {
+public @interface Nuke {
     
     /**
-     * Returns constraints which must be validated for this overwrite to
+     * Returns constraints which must be validated for this nuke to
      * succeed. See {@link Constraint} for details of constraint formats.
      * 
      * @return Constraints for this annotation
@@ -79,10 +79,10 @@ public @interface Overwrite {
 
     /**
      * By default, the annotation processor will attempt to locate an
-     * obfuscation mapping for all {@link Overwrite} methods since it is
-     * anticipated that in general the target of a {@link Overwrite} annotation
+     * obfuscation mapping for all {@link Nuke} methods since it is
+     * anticipated that in general the target of a {@link Nuke} annotation
      * will be an obfuscated method in the target class. However since it is
-     * possible to also overwrite methods in non-obfuscated targets it may be
+     * possible to also nuke methods in non-obfuscated targets it may be
      * necessary to suppress the compiler error which would otherwise be
      * generated. Setting this value to <em>false</em> will cause the annotation
      * processor to skip this annotation when attempting to build the

--- a/src/main/java/org/spongepowered/asm/mixin/Pseudo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Pseudo.java
@@ -44,7 +44,7 @@ import java.lang.annotation.Target;
  * <tt>initGui</tt> to be resolved in the superclass hierarchy (this is not the
  * case for normal mixins).</p>
  * 
- * <p>{@link Overwrite} methods which are <b>not</b> inherited from a superclass
+ * <p>{@link Nuke} methods which are <b>not</b> inherited from a superclass
  * (if the target is obfuscated) <b>must</b> be decorated manually with aliases.
  * </p>
  */

--- a/src/main/java/org/spongepowered/asm/mixin/Unique.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Unique.java
@@ -31,14 +31,14 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation, when applied to a member method or field in a mixin,
- * indicates that the member <b>should never</b> overwrite a matching member in
+ * indicates that the member <b>should never</b> nuke a matching member in
  * the target class. This indicates that the member differs from the normal
  * "overlay-like" behaviour of mixins in general, and should only ever be
  * <em>added</em> to the target. For public fields, the annotation has no
  * effect.
  * 
  * <p>Typical usage of this annotation would be to decorate a utility method in
- * a mixin, or mark an interface-implementing method which must not overwrite a
+ * a mixin, or mark an interface-implementing method which must not nuke a
  * target if it exists (consider appropriate use of {@link Intrinsic} in these
  * situations).</p>
  *

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -40,7 +40,7 @@ import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
 import org.spongepowered.asm.mixin.MixinEnvironment.Phase;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -97,19 +97,19 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     }
     
     /**
-     * Wrapper for overwrite options
+     * Wrapper for nuke options
      */
-    static class OverwriteOptions {
+    static class NukeOptions {
         
         @SerializedName("conformVisibility")
         boolean conformAccessModifiers;
         
         @SerializedName("requireAnnotations")
-        boolean requireOverwriteAnnotations;
+        boolean requireNukeAnnotations;
         
-        void mergeFrom(OverwriteOptions parent) {
+        void mergeFrom(NukeOptions parent) {
             this.conformAccessModifiers |= parent.conformAccessModifiers;
-            this.requireOverwriteAnnotations |= parent.requireOverwriteAnnotations;
+            this.requireNukeAnnotations |= parent.requireNukeAnnotations;
         }
         
     }
@@ -320,10 +320,10 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     private InjectorOptions injectorOptions;
     
     /**
-     * Overwrite options 
+     * Nuke options
      */
-    @SerializedName("overwrites")
-    private OverwriteOptions overwriteOptions;
+    @SerializedName("nukes")
+    private NukeOptions nukeOptions;
     
     /**
      * Config plugin, if supplied
@@ -383,8 +383,8 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
             this.injectorOptions = new InjectorOptions();
         }
         
-        if (this.overwriteOptions == null) {
-            this.overwriteOptions = new OverwriteOptions();
+        if (this.nukeOptions == null) {
+            this.nukeOptions = new NukeOptions();
         }
         
         return this.postInit();
@@ -430,10 +430,10 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
             this.injectorOptions.mergeFrom(this.parent.injectorOptions);
         }
         
-        if (this.overwriteOptions == null) {
-            this.overwriteOptions = this.parent.overwriteOptions;
+        if (this.nukeOptions == null) {
+            this.nukeOptions = this.parent.nukeOptions;
         } else {
-            this.overwriteOptions.mergeFrom(this.parent.overwriteOptions);
+            this.nukeOptions.mergeFrom(this.parent.nukeOptions);
         }
         
         this.setSourceFile |= this.parent.setSourceFile;
@@ -843,23 +843,23 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     }
     
     /**
-     * Get whether visibility levelfor overwritten methods should be conformed
+     * Get whether visibility levelfor nuked methods should be conformed
      * to the target class
      * 
      * @return true if conform is enabled
      */
-    public boolean conformOverwriteVisibility() {
-        return this.overwriteOptions.conformAccessModifiers;
+    public boolean conformNukeVisibility() {
+        return this.nukeOptions.conformAccessModifiers;
     }
     
     /**
-     * Get whether {@link Overwrite} annotations are required to enable
-     * overwrite behaviour for mixins in this config
+     * Get whether {@link Nuke} annotations are required to enable
+     * nuke behaviour for mixins in this config
      * 
-     * @return true to require overwriting methods to be annotated
+     * @return true to require nuking methods to be annotated
      */
-    public boolean requireOverwriteAnnotations() {
-        return this.overwriteOptions.requireOverwriteAnnotations;
+    public boolean requireNukeAnnotations() {
+        return this.nukeOptions.requireNukeAnnotations;
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -54,7 +54,7 @@ import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel.LanguageFeature;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
 import org.spongepowered.asm.mixin.MixinEnvironment.Phase;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -372,9 +372,9 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
                 
                 for (MethodNode method : this.validationClassNode.methods) {
                     this.validateRemappable(Shadow.class, method.name, Annotations.getVisible(method, Shadow.class));
-                    AnnotationNode overwrite = Annotations.getVisible(method, Overwrite.class);
-                    if (overwrite != null && ((method.access & Opcodes.ACC_STATIC) == 0 || (method.access & Opcodes.ACC_PUBLIC) == 0)) {
-                        throw new InvalidMixinException(MixinInfo.this, "Found @Overwrite annotation on " + method.name + " in " + MixinInfo.this);
+                    AnnotationNode nuke = Annotations.getVisible(method, Nuke.class);
+                    if (nuke != null && ((method.access & Opcodes.ACC_STATIC) == 0 || (method.access & Opcodes.ACC_PUBLIC) == 0)) {
+                        throw new InvalidMixinException(MixinInfo.this, "Found @Nuke annotation on " + method.name + " in " + MixinInfo.this);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -46,7 +46,7 @@ import org.objectweb.asm.tree.*;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.gen.AccessorInfo;
@@ -421,12 +421,12 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
     }
     
     /**
-     * Get whether overwrite annotations are required for methods in this mixin
+     * Get whether nuke annotations are required for methods in this mixin
      * 
-     * @return true if overwrite methods must be annoated with {@link Overwrite}
+     * @return true if nuke methods must be annoated with {@link Nuke}
      */
-    public boolean requireOverwriteAnnotations() {
-        return this.mixin.getParent().requireOverwriteAnnotations();
+    public boolean requireNukeAnnotations() {
+        return this.mixin.getParent().requireNukeAnnotations();
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/meta/MixinMerged.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/meta/MixinMerged.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * children.</p>
  * 
  * <p>Decoration annotation used by the mixin applicator to mark methods in a
- * class which have been added or overwritten by a mixin.</p>
+ * class which have been added or nuked by a mixin.</p>
  */
 @Target({ /* No targets allowed */ })
 @Retention(RetentionPolicy.RUNTIME)
@@ -48,7 +48,7 @@ public @interface MixinMerged {
     
     /**
      * Prioriy of the mixin which merged this method, used to allow mixins with
-     * higher priority to overwrite methods already overwritten by those with a
+     * higher priority to nuke methods already nuked by those with a
      * lower priority.
      * 
      * @return mixin priority

--- a/src/main/java/org/spongepowered/asm/util/Annotations.java
+++ b/src/main/java/org/spongepowered/asm/util/Annotations.java
@@ -42,7 +42,7 @@ import org.objectweb.asm.tree.MethodNode;
 import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Intrinsic;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Nuke;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -57,7 +57,7 @@ public final class Annotations {
      * Annotations which are eligible for merge via {@link #mergeAnnotations}
      */
     private static final Class<?>[] MERGEABLE_MIXIN_ANNOTATIONS = new Class<?>[] {
-        Overwrite.class,
+        Nuke.class,
         Intrinsic.class,
         Final.class,
         Debug.class

--- a/src/main/java/org/spongepowered/asm/util/Locals.java
+++ b/src/main/java/org/spongepowered/asm/util/Locals.java
@@ -108,15 +108,15 @@ public final class Locals {
      * method looking for stack frames and STORE opcodes. When either of these
      * is encountered, an attempt is made to cross-reference the values in the
      * stack map or STORE opcode with the value in the local variable table
-     * which covers the code range. Stack map frames overwrite the entire
+     * which covers the code range. Stack map frames nuke the entire
      * simulated local variable table with their own value types, STORE opcodes
-     * overwrite only the local slot to which they pertain. Values in the
+     * nuke only the local slot to which they pertain. Values in the
      * simulated locals array are spaced according to their size (unlike the
      * representation in FrameNode) and this TOP, NULL and UNINTITIALIZED_THIS
      * opcodes will be represented as null values in the simulated frame.</p>
      * 
      * <p>This code does not currently simulate the prescribed JVM behaviour
-     * where overwriting the second slot of a DOUBLE or LONG actually
+     * where nuking the second slot of a DOUBLE or LONG actually
      * invalidates the DOUBLE or LONG stored in the previous location, so we
      * have to hope (for now) that this behaviour isn't emitted by the compiler
      * or any upstream transformers. I may have to re-think this strategy if


### PR DESCRIPTION
I've noticed an incorrect description of the intended functionality with `@Overwrite` annotations. They don't overwrite the old method for say but instead steamrolls the old one. Since none of the actual bytecode is left behind due to this process, I have determined the most succinct name for this is `Nuking` rather than `overwriting` the method.

This PR fixes this naming mistake that has been present in the Mixin project for 4 years.

The specifics of the technical changes in this PR are listed below:

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent neque libero, varius in condimentum ut, malesuada eget enim. Fusce placerat volutpat leo, a viverra elit sagittis tempus. Vivamus tempor eget ante a fringilla. Quisque efficitur, libero in tempus molestie, purus dui accumsan nulla, at blandit arcu sem sed nisl. Aenean id justo quis mi laoreet pellentesque. Aliquam bibendum suscipit justo sed pharetra. Ut urna ligula, venenatis a magna ut, pulvinar efficitur ex. In non quam vel urna efficitur sollicitudin. Maecenas congue, ex et eleifend auctor, est sapien blandit diam, sit amet feugiat nunc tortor quis tortor. Mauris et venenatis sem. Maecenas posuere ligula sed nisi auctor pharetra. Vestibulum accumsan, nisl non porta dictum, elit sapien tristique nisl, eu tristique sem diam quis nunc. Donec lacinia leo metus, finibus venenatis dolor congue nec. Duis odio arcu, placerat sit amet blandit eget, laoreet at dui.

Cras elementum non neque nec malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus sollicitudin, nulla vel pulvinar congue, leo eros sodales nisi, condimentum pharetra tortor libero non nisl. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Proin condimentum mauris ut efficitur efficitur. Ut ligula massa, lacinia eu dictum nec, accumsan at lacus. Sed iaculis felis nisl, quis placerat est semper sit amet. Nam lobortis risus vel lacus elementum, ac dignissim nisl hendrerit. Ut vel justo tincidunt, semper turpis vitae, malesuada dui. Nullam tempus dui ut elementum egestas.

And a code example of how to use the new `@Nuke` decorator.
```java
@Mixin(Example.class)
public class Example {
    /**
     * @author Julius Ceaser
     * @reason roman license violations
     */
    @Nuke
    public /* copy the access level */ void /* copy the return type */ method /* copy the method name */ (String string /* copy the method parameters ?*/ )/* copy the end backet */ {
    // Commit license violations
    } /* copy end brace */
}
```

This requires support from the refmap system as the target needs to be remapped with the obfuscation tables.

> Why does this exist?

Yes.

> Yes

Yes.

>No

Yes.







Merge it you wont.