### PR TITLE
Explain priority order in javadocs

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/Mixin.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixin.java
@@ -57,7 +57,8 @@ public @interface Mixin {
 
     /**
      * Priority for the mixin, relative to other mixins targetting the same
-     * classes
+     * classes. Mixins with a lower priority are applied <i>before</i> mixins
+     * with a higher priority.
      * 
      * @return the mixin priority (relative to other mixins targetting the same
      *      class)


### PR DESCRIPTION
It's an easier quick reference than the wiki, if you forget the order.