### PR TITLE
RefMap Wrapper and @Desc annotation instead of string based target selectors.

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.tools.obfuscation.mirror;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -349,6 +350,23 @@ public abstract class TypeUtils {
         
         String returnType = TypeUtils.getInternalName(method.getReturnType());
         return String.format("(%s)%s", signature, returnType);
+    }
+
+    /**
+     * Get a bytecode-style descriptor for the specified return type and arguments 
+     * 
+     * @param ret Return type
+     * @param args Argument types
+     * @return descriptor
+     */
+    public static String getDescriptor(TypeMirror ret, Collection<TypeMirror> args) {
+    	StringBuilder signature = new StringBuilder();
+    	signature.append('(');
+    	for (TypeMirror arg : args)
+    		signature.append(TypeUtils.getInternalName(arg));
+    	signature.append(')');
+    	signature.append(TypeUtils.getInternalName(ret));
+    	return signature.toString();
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/injection/Desc.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/Desc.java
@@ -1,0 +1,8 @@
+package org.spongepowered.asm.mixin.injection;
+
+public @interface Desc {
+	public Class<?> owner() default Void.class;
+	public String value();
+	public Class<?> ret() default Void.class;
+	public Class<?>[] args() default { };
+}

--- a/src/main/java/org/spongepowered/asm/mixin/injection/Inject.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/Inject.java
@@ -122,7 +122,16 @@ public @interface Inject {
      * 
      * @return target method(s) for this injector
      */
-    public String[] method();
+    public String[] method() default {};
+    
+    /**
+     * Object reference to one or more
+     * {@link ITargetSelector target selectors} which identify the target
+     * methods.
+     * 
+     * @return target method(s) for this injector
+     */
+    public Desc[] target() default {};
     
     /**
      * Array of {@link Slice} annotations which describe the method bisections


### PR DESCRIPTION
Some of the idea we discussed to make it easier to automate remapping of Mixins. 
Needs documentation written up but functional.
Mainly a sanity check and look into other things that would use this.
Basically, the two places {AP and InjectionInfo} I could find that use the string based 'methods' argument of `@Inject` have been expanded to also allow for annotated descriptors.

There are a few things to note:
The default for args is a empty array, this is meant to specifically mean 'target a method with 0 arguments' NOT 'find the correct arguments based on name'. 
The Default for return is void, because that just makes sense IMO, and again it's specifically designated that and won't find a 'valid'.
The default for owner is null and it IS designed to explicitly use the first target from the `@Mixin` annotation. This is just a sane compromise between verbosity and functionality.

The intention is to make the logic behind the selectors simpler, a lot less guessing. This way things like Mercury/S2S don't have to inspect the mixin targets. Ideally, we'd also expand this `@Desc` to use in other things like Field/Method opcode targets but I would need examples of the existing way to target those.

Here is an example, all of which target the same method.
```java
@Mixin(MainMenuScreen.class)
public class Test {

    @Shadow
    private String splashText;

    @Inject(at = @At("TAIL"), target = @Desc(owner = MainMenuScreen.class, value = "init", ret = Void.class, args = {}))
    //@Inject(at = @At("TAIL"), target = @Desc(owner = MainMenuScreen.class, value = "init"))
    //@Inject(at = @At("TAIL"), target = @Desc("init"))
    //@Inject(at = @At("TAIL"), method = "init()V")
    //@Inject(at = @At("TAIL"), method = "init")
    protected void fixSplash(CallbackInfo ci) {
        this.splashText = "Mixins Work!";
    }
}
```

The ref wrapper is the other idea, which would allow us to control remapping the names themselves, allowing us to introduce something that bypasses/proxies the SRG names so that they won't be replaced by your dev env and thus don't need to be remapped at the source level. But I couldn't find a way to hook this into the AP so I think it may be a dead idea.