### PR TITLE
Allows < and > to be written as characters instead of unicode codes

### DIFF
--- a/src/example/java/org/spongepowered/tools/obfuscation/json/MappingWriterJson.java
+++ b/src/example/java/org/spongepowered/tools/obfuscation/json/MappingWriterJson.java
@@ -79,7 +79,7 @@ public class MappingWriterJson extends MappingWriter {
         
         try {
             writer = this.openFileWriter(output, type + " output");
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
             gson.toJson(mappings, writer);
         } catch (IOException ex) {
             ex.printStackTrace();

--- a/src/main/java/org/spongepowered/asm/mixin/refmap/ReferenceMapper.java
+++ b/src/main/java/org/spongepowered/asm/mixin/refmap/ReferenceMapper.java
@@ -246,7 +246,7 @@ public final class ReferenceMapper implements IReferenceMapper, Serializable {
      * @param writer Writer to write to
      */
     public void write(Appendable writer) {
-        new GsonBuilder().setPrettyPrinting().create().toJson(this, writer);
+        new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(this, writer);
     }
     
     /**


### PR DESCRIPTION
Fixes the issue where a refmap entry containing `<init>` is written to file as `\u003cinit\u003e`.