### PR TITLE
Fix TSRGv2 parsing

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/mapping/fg3/MappingProviderTSrg.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/mapping/fg3/MappingProviderTSrg.java
@@ -65,7 +65,7 @@ public class MappingProviderTSrg extends MappingProvider {
         this.inputMappings.addAll(Files.readLines(input, Charset.defaultCharset()));
         
         for (String line : this.inputMappings) {
-            if (Strings.isNullOrEmpty(line) || line.startsWith("#")) {
+            if (Strings.isNullOrEmpty(line) || line.startsWith("#") || line.startsWith("tsrg2") || line.startsWith("\t\t")) {
                 continue;
             }
             


### PR DESCRIPTION
ForgeGradle 5 now outputs TSRGv2 by default for `createMcpToSrg` and related `GenerateSrg` tasks. This is a simple fix to incorporate the TSRGv2 format into the existing TSRG parser. Two tabs in the format means either a method parameter or denoting whether the method is static. There is also an extra first line provided at the beginning of the file. Neither of these things are necessary to use the TSRG file in mixin, so they are filtered out.