### PR TITLE
allow INVOKE_ASSIGN to work with casts

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/points/AfterInvoke.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/points/AfterInvoke.java
@@ -82,6 +82,10 @@ public class AfterInvoke extends BeforeInvoke {
         }
         
         insn = InjectionPoint.nextNode(insns, insn);
+        if(insn instanceof TypeInsnNode && insn.getOpcode() == Opcodes.CHECKCAST) {
+            insn = InjectionPoint.nextNode(insns, insn);
+        }
+        
         if (insn instanceof VarInsnNode && insn.getOpcode() >= Opcodes.ISTORE) {
             insn = InjectionPoint.nextNode(insns, insn);
         }


### PR DESCRIPTION
The title says it all, this is particularly relevant for generics

```
...
invokevirtual Map#get
checkcast T
store 10
```