### PR TITLE
Adjust modularity build configuration to avoid duplicate sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ ext.legacyForgeAsmVersion = project.hasProperty("legacyForgeAsmVersion") ? asmVe
 ext.doSignJar = project.hasProperty("keyStorePath")
 
 java {
+    modularity.inferModulePath = false
     toolchain.languageVersion = JavaLanguageVersion.of(ciSystem == 'unknown' ? 16 : 8)
 }
 
@@ -97,6 +98,7 @@ sourceSets {
         compileClasspath += main.output
         ext.languageVersion = 8
         ext.compatibility = '1.6'
+        ext.modularityExcluded = true
     }
     agent {
         compileClasspath += main.output
@@ -107,10 +109,15 @@ sourceSets {
         compileClasspath += main.output
         ext.languageVersion = 8
         ext.compatibility = '1.8'
+        ext.modularityExcluded = true
     }
     example {
         compileClasspath += main.output
         compileClasspath += ap.output
+        ext.modularityExcluded = true
+    }
+    test {
+        ext.modularityExcluded = true
     }
     launchwrapper {
         compileClasspath += main.output
@@ -135,14 +142,7 @@ sourceSets {
     }
     modularity {
         ext.languageVersion = 16
-        java.srcDirs += [
-            sourceSets.legacy.java.srcDirs,
-            sourceSets.main.java.srcDirs,
-            sourceSets.ap.java.srcDirs,
-            sourceSets.agent.java.srcDirs,
-            sourceSets.modlauncher.java.srcDirs,
-            sourceSets.modlauncher9.java.srcDirs
-        ]
+        ext.modularityExcluded = true // don't add ourselves
     }
 }
 
@@ -203,14 +203,6 @@ dependencies {
     legacyImplementation "org.ow2.asm:asm-tree:$asmVersion"
     
     modularityCompileOnly 'org.apache.logging.log4j:log4j-core:2.11.2'
-}
-
-compileModularityJava {
-    doFirst {
-        options.compilerArgs = [
-            '--module-path', classpath.asPath
-        ]
-    }
 }
 
 javadoc {
@@ -285,7 +277,6 @@ checkstyle {
     ]
     configFile = file("checkstyle.xml")
     toolVersion = '8.43'
-    sourceSets -= project.sourceSets['modularity']
 }
 
 // Source compiler configuration
@@ -294,6 +285,8 @@ tasks.withType(JavaCompile) {
     options.deprecation = true
     options.encoding = 'utf8'
 }
+
+def modularityInputs = objects.fileCollection()
 
 project.sourceSets.each { set -> {
     if (set.ext.has("languageVersion")) {
@@ -305,7 +298,24 @@ project.sourceSets.each { set -> {
         project.tasks[set.compileJavaTaskName].sourceCompatibility = set.ext.compatibility
         project.tasks[set.compileJavaTaskName].targetCompatibility = set.ext.compatibility
     }
+    def modularityExcluded = set.ext.has("modularityExcluded") && set.ext.modularityExcluded
+    if (!modularityExcluded) {
+        project.sourceSets.modularity {
+            compileClasspath += set.output
+        }
+        modularityInputs.from set.output
+    }
 }}
+
+compileModularityJava {
+    inputs.files(modularityInputs)
+    doFirst {
+        options.compilerArgs = [
+            '--module-path', classpath.asPath,
+            '--patch-module', "org.spongepowered.mixin=${modularityInputs.collect { it.absolutePath }.join(File.pathSeparator)}"
+        ]
+    }
+}
 
 if (JavaVersion.current().isJava8Compatible()) {
     tasks.withType(Javadoc) {
@@ -318,8 +328,6 @@ task stagingJar(type: ShadowJar) {
     sourceSets.findAll { !(it.name =~ /example|test/) }.each {
         from it.output
     }
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    
     configurations = [project.configurations.stagingJar]
     
     // JAR manifest configuration

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,6 +11,9 @@
 <module name="Checker">
   <property name="severity" value="warning"/>
   <property name="charset" value="UTF-8"/>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
   <module name="TreeWalker">
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">

--- a/src/main/java/org/spongepowered/asm/util/PrettyPrinter.java
+++ b/src/main/java/org/spongepowered/asm/util/PrettyPrinter.java
@@ -1147,7 +1147,7 @@ public class PrettyPrinter {
 
     private void logString(ILogger logger, Level level, String line) {
         if (line != null) {
-            logger.log(level, "/* {} */", String.format("%-" + this.width, line));
+            logger.log(level, "/* {} */", String.format("%-" + this.width + "s", line));
         }
     }
     


### PR DESCRIPTION
This allows the shadow task to apply its own merging logic for
resources that are validly duplicated, in this case service files.

The checkstyle exclusion for module-info is moved from the
buildscript to checkstyle.xml, for application within IDEs, not just
Gradle. This is based on the Checkstyle example for Google code style.

A small fix to PrettyPrinter is included as well, based on a line
incorrectly converted from log4j2.