### PR TITLE
build: Synthesize modules to link with multiple versions of libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ dependency-reduced-pom.xml
 # Compiled #
 ############
 bin
-build
+/build
+/build-logic/build
 dist
 out
 run

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java-gradle-plugin'
+}
+
+java {
+    sourceCompatibility 'VERSION_1_8'
+    targetCompatibility 'VERSION_1_8'
+}
+
+repositories {
+    maven {
+        name 'sponge'
+        url 'https://repo.spongepowered.org/repository/maven-public'
+    }
+}
+
+dependencies {
+    implementation 'org.ow2.asm:asm:9.2'
+}
+
+gradlePlugin {
+    plugins {
+        syntheticModules {
+            id = 'synthetic-modules'
+            implementationClass = 'org.spongepowered.asm.mixin.build.SyntheticModulesPlugin'
+        }
+    }
+}

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'Mixin-build-logic'

--- a/build-logic/src/main/java/org/spongepowered/asm/mixin/build/GenerateModule.java
+++ b/build-logic/src/main/java/org/spongepowered/asm/mixin/build/GenerateModule.java
@@ -1,0 +1,53 @@
+package org.spongepowered.asm.mixin.build;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+
+public abstract class GenerateModule extends DefaultTask {
+
+    private static final long STABLE_TIMESTAMP = 0x386D4380; // 01/01/2000 00:00:00 java 8 breaks when using 0.
+
+    @OutputFile
+    public abstract RegularFileProperty getGeneratedJar();
+
+    @Input
+    public abstract Property<String> getModuleName();
+
+    @TaskAction
+    public void generateSyntheticModule() throws IOException {
+        this.getGeneratedJar().get().getAsFile().getParentFile().mkdirs(); // create directories if needed
+
+        // write a jar with a single file, of the synthetic module-info
+        try (final JarOutputStream jos = new JarOutputStream(new FileOutputStream(this.getGeneratedJar().get().getAsFile()))) {
+            final ZipEntry entry = new ZipEntry("module-info.class");
+            entry.setTime(STABLE_TIMESTAMP);
+            jos.putNextEntry(entry);
+            this.writeModule(jos);
+            jos.closeEntry();
+        }
+    }
+
+    private void writeModule(final OutputStream os) throws IOException {
+        final ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        final ModuleVisitor mv = cw.visitModule(this.getModuleName().get(), 0, null);
+        mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+        mv.visitEnd();
+        cw.visitEnd();
+        os.write(cw.toByteArray());
+    }
+
+}

--- a/build-logic/src/main/java/org/spongepowered/asm/mixin/build/SyntheticModulesExtension.java
+++ b/build-logic/src/main/java/org/spongepowered/asm/mixin/build/SyntheticModulesExtension.java
@@ -1,0 +1,40 @@
+package org.spongepowered.asm.mixin.build;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.TaskProvider;
+
+import javax.inject.Inject;
+
+public class SyntheticModulesExtension {
+    private final Project project;
+    private final DirectoryProperty outputDirectory;
+
+    @Inject
+    public SyntheticModulesExtension(final ObjectFactory objects, final Project project) {
+        this.project = project;
+        this.outputDirectory = objects.directoryProperty();
+    }
+
+    public DirectoryProperty getOutputDirectory() {
+        return this.outputDirectory;
+    }
+
+    // This is far from idiomatic gradle -- we should have a NamedDomainObjectCollection for the
+    // data model, and create tasks based on the contents of that collection
+    // however, this is a simple thing for internal use, so instead we just create tasks directly
+    public void module(final String moduleName) {
+        final String sanitizedName = moduleName.replace('.', '_');
+        final TaskProvider<GenerateModule> t = this.project.getTasks().register("generateModule" + sanitizedName, GenerateModule.class, task -> {
+            task.getModuleName().set(moduleName);
+            task.getGeneratedJar().set(this.getOutputDirectory().file(sanitizedName + ".jar"));
+        });
+
+        this.project.getPlugins().withType(JavaPlugin.class, $ -> {
+            this.project.getDependencies().add(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, this.project.files(t.map(it -> it.getOutputs())));
+        });
+    }
+
+}

--- a/build-logic/src/main/java/org/spongepowered/asm/mixin/build/SyntheticModulesPlugin.java
+++ b/build-logic/src/main/java/org/spongepowered/asm/mixin/build/SyntheticModulesPlugin.java
@@ -1,0 +1,42 @@
+package org.spongepowered.asm.mixin.build;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+public class SyntheticModulesPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        this.createExtension(project);
+
+        // create aggregator task
+        final TaskProvider<?> aggregator = this.createAggregatorTask(project.getTasks());
+
+        // setup IDE integration
+        this.configureIdes(project, aggregator);
+    }
+
+    private void createExtension(final Project project) {
+        final SyntheticModulesExtension extension = project.getExtensions()
+            .create("syntheticModules", SyntheticModulesExtension.class, project);
+
+        extension.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("generated-modules"));
+    }
+
+    private TaskProvider<?> createAggregatorTask(final TaskContainer tasks) {
+        return tasks.register("generateAllSyntheticModules", task -> {
+            task.dependsOn(tasks.withType(GenerateModule.class));
+        });
+    }
+
+    private void configureIdes(final Project project, final TaskProvider<?> aggregatorTask) {
+        project.getPlugins().withType(EclipsePlugin.class, pl -> {
+            project.getExtensions().getByType(EclipseModel.class).synchronizationTasks(aggregatorTask);
+        });
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ buildscript {
     }
 }
 
+plugins {
+  id 'java'
+  id 'synthetic-modules'
+}
+
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 // Apply plugin
@@ -77,6 +82,7 @@ configurations {
     modlauncherImplementation   .extendsFrom implementation
     modlauncher9Implementation  .extendsFrom modlauncherImplementation
     modularityImplementation    .extendsFrom modlauncher9Implementation
+    modularityCompileOnly       .extendsFrom compileOnly
 }
 
 sourceSets {
@@ -144,6 +150,15 @@ sourceSets {
         ext.languageVersion = 16
         ext.modularityExcluded = true // don't add ourselves
     }
+}
+
+// Because Mixin aims to support a variety of environments, we have to be able to run with older versions of GSON and Guava that lack 
+// official module names. This means the same library may appear with multiple module names. We want to be able to link our module with 
+// either of these two at runtime, without having to have two versions of the library on our compile-time module path.
+// To do this, we generate empty jars with *only* a module descriptor for the module we want to be able to compile against.
+syntheticModules {
+    module 'com.google.gson'
+    module 'com.google.common'
 }
 
 // Project dependencies

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = name
+
+includeBuild 'build-logic'

--- a/src/modularity/java/module-info.java
+++ b/src/modularity/java/module-info.java
@@ -40,7 +40,7 @@ module org.spongepowered.mixin {
     requires transitive org.objectweb.asm.tree.analysis;
     requires transitive org.objectweb.asm.util;
     requires java.logging;
-    
+
     //
     // Modules we require for compilation but don't necessarily need at runtime
     //
@@ -48,12 +48,18 @@ module org.spongepowered.mixin {
     requires static transitive cpw.mods.modlauncher;
     requires static cpw.mods.securejarhandler;
     requires static transitive org.apache.logging.log4j;
-    
+
     //
     // Automatic modules we depend on, using static to avoid the forward compatibility mess
     //
     requires static jopt.simple;
+
+    // Guava, by file name and official module
+    requires static com.google.common;
     requires static guava;
+
+    // Gson, by file name and official module
+    requires static com.google.gson;
     requires static gson;
 
     //
@@ -105,11 +111,10 @@ module org.spongepowered.mixin {
     exports org.spongepowered.tools.obfuscation.mcp;
     exports org.spongepowered.tools.obfuscation.mirror;
     exports org.spongepowered.tools.obfuscation.service;
-    
-    // one of these won't exist, the SuppressWarnings above stops the compiler complaining
+
     opens org.spongepowered.asm.mixin.transformer
         to com.google.gson, gson;
-    
+
     //
     // Service wiring
     //
@@ -132,7 +137,7 @@ module org.spongepowered.mixin {
     uses cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
     provides cpw.mods.modlauncher.serviceapi.ILaunchPluginService
         with org.spongepowered.asm.launch.MixinLaunchPlugin;
-    
+
     uses javax.annotation.processing.Processor;
     provides javax.annotation.processing.Processor
         with org.spongepowered.tools.obfuscation.MixinObfuscationProcessorInjection,


### PR DESCRIPTION
Gson and Guice are both used in pre- and post-modular versions in
environments where Mixin is used on the module path, so we have to be
able to link against both in the compile-time module descriptor.

Tested briefly on Forge's 1.18 branch, and it seems to resolve the modularity issues they were having.