### PR TITLE
AP Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ sourceSets {
     ap {
         compileClasspath += main.output
         ext.languageVersion = 8
-        ext.compatibility = '1.6'
+        ext.compatibility = '1.8'
     }
     fernflower {
         compileClasspath += main.output

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
@@ -73,6 +73,7 @@ import org.spongepowered.tools.obfuscation.mirror.TypeHandle;
 import org.spongepowered.tools.obfuscation.mirror.TypeHandleASM;
 import org.spongepowered.tools.obfuscation.mirror.TypeHandleSimulated;
 import org.spongepowered.tools.obfuscation.mirror.TypeReference;
+import org.spongepowered.tools.obfuscation.mirror.TypeUtils;
 import org.spongepowered.tools.obfuscation.struct.InjectorRemap;
 import org.spongepowered.tools.obfuscation.validation.ParentValidator;
 import org.spongepowered.tools.obfuscation.validation.TargetValidator;
@@ -688,6 +689,24 @@ final class AnnotatedMixins implements IMixinAnnotationProcessor, ITokenProvider
         name = name.replace('/', '.');
 
         Elements elements = this.processingEnv.getElementUtils();
+        PackageElement pkg = null;
+
+        int lastDotPos = name.lastIndexOf('.');
+        if (lastDotPos > -1) {
+            String pkgName = name.substring(0, lastDotPos);
+            pkg = elements.getPackageElement(pkgName);
+        }
+
+        if (pkg != null) {
+            // ASM gives the most and most accurate information. Try that first.
+            TypeHandle asmTypeHandle = TypeHandleASM.of(pkg, name.substring(lastDotPos + 1), this);
+            if (asmTypeHandle != null) {
+                return asmTypeHandle;
+            }
+        }
+
+        // ASM may be unable to resolve the class, for example if it's currently being compiled.
+        // Mirror is our next best bet.
         TypeElement element = this.getTypeElement(name, elements);
         if (element != null) {
             try {
@@ -697,25 +716,12 @@ final class AnnotatedMixins implements IMixinAnnotationProcessor, ITokenProvider
             }
         }
 
-        int lastDotPos = name.lastIndexOf('.');
-        if (lastDotPos > -1) {
-            String pkgName = name.substring(0, lastDotPos);
-            PackageElement pkg = elements.getPackageElement(pkgName);
-            if (pkg != null) {
-                // If we can resolve the package but not the class, it's possible
-                // we're dealing with a class that mirror can't access, such as
-                // an anonymous class. The class might be available via the
-                // classpath though, so let's attempt to read the class with ASM
-                TypeHandle asmTypeHandle = TypeHandleASM.of(pkg, name.substring(lastDotPos + 1), this);
-                if (asmTypeHandle != null) {
-                    return asmTypeHandle;
-                }
-                
-                // Couldn't resolve the class, so just return an imaginary handle
-                return new TypeHandle(pkg, name);
-            }
+        if (pkg != null) {
+            // Couldn't resolve the class, but could resolve the package, so just return an imaginary handle.
+            return new TypeHandle(pkg, name);
         }
-        
+
+        // Couldn't even resolve the package, all hope is lost.
         return null;
     }
     
@@ -728,11 +734,11 @@ final class AnnotatedMixins implements IMixinAnnotationProcessor, ITokenProvider
         if (type instanceof TypeHandle) {
             return (TypeHandle)type;
         } else if (type instanceof DeclaredType) {
-            return new TypeHandle((DeclaredType)type);
+            return this.getTypeHandle(TypeUtils.getInternalName((DeclaredType) type));
         } else if (type instanceof Type) {
             return this.getTypeHandle(((Type)type).getClassName());
         } else if (type instanceof TypeElement) {
-            return new TypeHandle((DeclaredType)((TypeElement)type).asType());
+            return this.getTypeHandle(TypeUtils.getInternalName((TypeElement) type));
         } else if (type instanceof String) {
             return this.getTypeHandle(type.toString());
         }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
@@ -37,6 +37,7 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.IntersectionType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -447,6 +448,10 @@ public abstract class TypeUtils {
         if (depth == 0) {
             throw new IllegalStateException("Generic symbol \"" + type + "\" is too complex, exceeded "
                     + TypeUtils.MAX_GENERIC_RECURSION_DEPTH + " iterations attempting to determine upper bound");
+        }
+        if (type instanceof IntersectionType) {
+            TypeMirror first = ((IntersectionType) type).getBounds().get(0);
+            return TypeUtils.getUpperBound0(first, --depth);
         }
         if (type instanceof DeclaredType) {
             return (DeclaredType)type;


### PR DESCRIPTION
This fixes 2 issues:
1. Even when lambdas and such have mappings, they are not remapped due to Mirror being prioritised over ASM.
2. Intersection types are not resolved properly by the AP and as such do not get remapped.

This PR fixes those and builds a fully working version of FabricAPI, with all lambdas properly in the refmaps.
Closes https://github.com/SpongePowered/Mixin/issues/590 and closes https://github.com/SpongePowered/Mixin/issues/507