### PR TITLE
Relocate dependencies within the processor jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,8 @@ configurations.archives.artifacts.clear()
 shadowJar  {
     from sourceSets.ap.output
     classifier = 'processor'
+    relocate("org.objectweb.asm", "org.spongepowered.asm.shadow.asm")
+    relocate("com.google", "org.spongepowered.asm.shadow.com.google")
 }
 build.dependsOn(shadowJar)
 


### PR DESCRIPTION
If an annotation processor depends on a more recent version of one of Mixin's dependencies, it's possible that the outdated class from Mixin's processor jar will be used instead, resulting in `NoSuchMethodError`s during compilation.

Instead, we relocate the shadowed dependencies to live within the `org.spongepowered.asm.shadow` package instead, allowing them to co-exist with other processors.