### PR TITLE
Fix `Args` subclass generation on modern ModLauncher.

### DIFF
--- a/src/main/java/org/spongepowered/asm/synthetic/args/Dummy.java
+++ b/src/main/java/org/spongepowered/asm/synthetic/args/Dummy.java
@@ -1,0 +1,8 @@
+package org.spongepowered.asm.synthetic.args;
+
+/**
+ * On modern ModLauncher, generation of synthetic `Args` classes fails unless the module already exists.
+ * For the module to exist, a class needs to be present in its package prior to generation, so that's what this class is for.
+ */
+class Dummy {
+}


### PR DESCRIPTION
Title says it all. `ModifyArgs` is usable now.