### PR TITLE
Fixes crashes caused by reflection loading.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -70,7 +70,7 @@ import org.spongepowered.asm.util.perf.Profiler.Section;
 /**
  * Heart of the Mixin pipeline 
  */
-class MixinProcessor {
+public class MixinProcessor {
 
     /**
      * Phase during which an error occurred, delegates to functionality in

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -505,7 +505,15 @@ public class MixinProcessor {
         
         Collections.sort(this.pendingConfigs);
     }
-
+    
+    /**
+     * Literally only here to prevent a crash because some mods use reflection to access this method.
+     */
+    @Deprecated
+    private int prepareConfigs(MixinEnvironment environment) {
+        this.prepareConfigs(environment, this.extensions);
+    }
+    
     /**
      * Prepare mixin configs
      * 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
@@ -42,7 +42,7 @@ import org.spongepowered.asm.util.asm.ASM;
 /**
  * Transformer which manages the mixin configuration and application process
  */
-final class MixinTransformer extends TreeTransformer implements IMixinTransformer {
+public final class MixinTransformer extends TreeTransformer implements IMixinTransformer {
     
     /**
      * Impl of mixin transformer factory


### PR DESCRIPTION
The most popular method to load Mixins in a way that they can modify other mods is to use Dimensional Development's strategy of invoking a few key methods in MixinProcessor via reflection. This is no longer possible since these elements have been removed.  This PR adds them back in a deprecated form as a mainstay against an outright crash.

Normally I'd be all for removing these things entirely, but the problem is that this is as far as I can tell the _only_ way to modify other mods in 1.12, meaning that if any mod decides to include 0.8, every other mod that uses this method to load its mixins will cause crashes immediately.