### PR TITLE
Fix issue #622. Mixin fails if `FileObject.toUri()` doesn't represent a real file.

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/ReferenceManager.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/ReferenceManager.java
@@ -155,7 +155,11 @@ public class ReferenceManager implements IReferenceManager {
         }
         
         FileObject outResource = this.ap.getProcessingEnvironment().getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", fileName);
-        this.ap.printMessage(MessageType.INFO, "Writing " + description + " to " + new File(outResource.toUri()).getAbsolutePath());
+        try { // we cannot assume outResource.toUri() is a file:// uri.
+                this.ap.printMessage(MessageType.INFO, "Writing " + description + " to " + new File(outResource.toUri()).getAbsolutePath());
+        } catch (IllegalArgumentException ignored) {
+                this.ap.printMessage(MessageType.INFO, "Writing " + description + " to " + outResource.toUri());
+        }
         return new PrintWriter(outResource.openWriter());
     }
 


### PR DESCRIPTION
fixed this by just putting it in a try-catch, if it fails just print the URI instead, that's good enough