### PR TITLE
Determine ModLauncher-Version from ModLauncher-Environment rather than Package

### DIFF
--- a/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
+++ b/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
@@ -27,7 +27,10 @@ package org.spongepowered.asm.service.modlauncher;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
+import java.util.Optional;
 
+import cpw.mods.modlauncher.api.IEnvironment;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import org.spongepowered.asm.launch.IClassProcessor;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleModLauncher;
 import org.spongepowered.asm.logging.ILogger;
@@ -47,6 +50,7 @@ import com.google.common.collect.ImmutableList;
 
 import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.ITransformationService;
+import org.spongepowered.asm.util.VersionNumber;
 
 /**
  * Mixin service for ModLauncher
@@ -56,7 +60,7 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     /**
      * Specification version to check for at startup
      */
-    private static final String MODLAUNCHER_4_SPECIFICATION_VERSION = "4.0";
+    private static final VersionNumber MODLAUNCHER_4_SPECIFICATION_VERSION = VersionNumber.parse("4.0");
     
     /**
      * Specification version for ModLauncher versions &gt;= 9.0.4, yes this is
@@ -65,8 +69,8 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
      * version 5.0 for example, and ML7 and ML8 both had specification version
      * 7.0).
      */
-    private static final String MODLAUNCHER_9_SPECIFICATION_VERSION = "8.0";
-    
+    private static final VersionNumber MODLAUNCHER_9_SPECIFICATION_VERSION = VersionNumber.parse("8.0");
+
     private static final String CONTAINER_PACKAGE = MixinServiceAbstract.LAUNCH_PACKAGE + "platform.container.";
     private static final String MODLAUNCHER_4_ROOT_CONTAINER_CLASS = MixinServiceModLauncher.CONTAINER_PACKAGE + "ContainerHandleModLauncher";
     private static final String MODLAUNCHER_9_ROOT_CONTAINER_CLASS = MixinServiceModLauncher.CONTAINER_PACKAGE + "ContainerHandleModLauncherEx";
@@ -117,15 +121,15 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     private CompatibilityLevel minCompatibilityLevel = CompatibilityLevel.JAVA_8;
     
     public MixinServiceModLauncher() {
-        final Package pkg = ITransformationService.class.getPackage();
-        if (pkg.isCompatibleWith(MixinServiceModLauncher.MODLAUNCHER_9_SPECIFICATION_VERSION)) {
+        VersionNumber apiVersion = getModLauncherApiVersion();
+        if (apiVersion.compareTo(MODLAUNCHER_9_SPECIFICATION_VERSION) >= 0) {
             this.createRootContainer(MixinServiceModLauncher.MODLAUNCHER_9_ROOT_CONTAINER_CLASS);
             this.minCompatibilityLevel = CompatibilityLevel.JAVA_16;
         } else {
             this.createRootContainer(MixinServiceModLauncher.MODLAUNCHER_4_ROOT_CONTAINER_CLASS);
         }
     }
-    
+
     /**
      * Begin init
      * 
@@ -200,9 +204,8 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     @Override
     public boolean isValid() {
         try {
-            Launcher.INSTANCE.hashCode();
-            final Package pkg = ITransformationService.class.getPackage();
-            if (!pkg.isCompatibleWith(MixinServiceModLauncher.MODLAUNCHER_4_SPECIFICATION_VERSION)) {
+            VersionNumber apiVersion = getModLauncherApiVersion();
+            if (apiVersion.compareTo(MixinServiceModLauncher.MODLAUNCHER_4_SPECIFICATION_VERSION) < 0) {
                 return false;
             }
         } catch (Throwable th) {
@@ -309,6 +312,22 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
             this.getTransformationHandler(),
             (IClassProcessor)this.getClassTracker()
         );
+    }
+
+    private static VersionNumber getModLauncherApiVersion() {
+        Optional<String> version = Optional.empty();
+        try {
+            TypesafeMap.Key<String> versionProperty = IEnvironment.Keys.MLSPEC_VERSION.get();
+            version = Launcher.INSTANCE.environment().getProperty(versionProperty);
+        } catch (Exception ignored) {
+        }
+
+        // Fall back to the package information (this is not present when loaded as a module)
+        if (!version.isPresent()) {
+            version = Optional.ofNullable(ITransformationService.class.getPackage().getSpecificationVersion());
+        }
+
+        return version.map(VersionNumber::parse).orElse(VersionNumber.NONE);
     }
 
 }

--- a/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
+++ b/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
@@ -29,8 +29,6 @@ import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Optional;
 
-import cpw.mods.modlauncher.api.IEnvironment;
-import cpw.mods.modlauncher.api.TypesafeMap;
 import org.spongepowered.asm.launch.IClassProcessor;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleModLauncher;
 import org.spongepowered.asm.logging.ILogger;
@@ -49,7 +47,9 @@ import org.spongepowered.asm.util.IConsumer;
 import com.google.common.collect.ImmutableList;
 
 import cpw.mods.modlauncher.Launcher;
+import cpw.mods.modlauncher.api.IEnvironment;
 import cpw.mods.modlauncher.api.ITransformationService;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import org.spongepowered.asm.util.VersionNumber;
 
 /**
@@ -121,7 +121,7 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     private CompatibilityLevel minCompatibilityLevel = CompatibilityLevel.JAVA_8;
     
     public MixinServiceModLauncher() {
-        VersionNumber apiVersion = getModLauncherApiVersion();
+        VersionNumber apiVersion = MixinServiceModLauncher.getModLauncherApiVersion();
         if (apiVersion.compareTo(MODLAUNCHER_9_SPECIFICATION_VERSION) >= 0) {
             this.createRootContainer(MixinServiceModLauncher.MODLAUNCHER_9_ROOT_CONTAINER_CLASS);
             this.minCompatibilityLevel = CompatibilityLevel.JAVA_16;
@@ -204,7 +204,7 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     @Override
     public boolean isValid() {
         try {
-            VersionNumber apiVersion = getModLauncherApiVersion();
+            VersionNumber apiVersion = MixinServiceModLauncher.getModLauncherApiVersion();
             if (apiVersion.compareTo(MixinServiceModLauncher.MODLAUNCHER_4_SPECIFICATION_VERSION) < 0) {
                 return false;
             }
@@ -315,12 +315,8 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     }
 
     private static VersionNumber getModLauncherApiVersion() {
-        Optional<String> version = Optional.empty();
-        try {
-            TypesafeMap.Key<String> versionProperty = IEnvironment.Keys.MLSPEC_VERSION.get();
-            version = Launcher.INSTANCE.environment().getProperty(versionProperty);
-        } catch (Exception ignored) {
-        }
+        TypesafeMap.Key<String> versionProperty = IEnvironment.Keys.MLSPEC_VERSION.get();
+        Optional<String> version = Launcher.INSTANCE.environment().getProperty(versionProperty);
 
         // Fall back to the package information (this is not present when loaded as a module)
         if (!version.isPresent()) {


### PR DESCRIPTION
Rely on the ML-Specification version present in the ModLauncher environment rather than on the Package specification version, since that version is unavailable in two scenarios: 1) ML loaded as a JPMS module and 2) ML added to the classpath using a folder rather than JAR-file.

Fixes #656

p.s.: I do not know how to test this using ModLauncher 4, to be honest. And it obviously needs more testing in general.