### PR TITLE
Add stack checking to old `Target#findInitNodeFor` overload and un-deprecate it.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/Target.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/Target.java
@@ -638,25 +638,9 @@ public class Target implements Comparable<Target>, Iterable<AbstractInsnNode> {
      * 
      * @param newNode NEW insn
      * @return INVOKESPECIAL opcode of ctor, or null if not found
-     * 
-     * @deprecated Use {@link #findInitNodeFor(TypeInsnNode, String)} instead:
-     *      this method only matches the first matching <tt>&lt;init&gt;</tt>
-     *      after the specified <tt>NEW</tt>, it also does not filter based on
-     *      the descriptor passed into <tt>BeforeNew</tt>.
      */
-    @Deprecated
     public MethodInsnNode findInitNodeFor(TypeInsnNode newNode) {
-        int start = this.indexOf(newNode);
-        for (Iterator<AbstractInsnNode> iter = this.insns.iterator(start); iter.hasNext();) {
-            AbstractInsnNode insn = iter.next();
-            if (insn instanceof MethodInsnNode && insn.getOpcode() == Opcodes.INVOKESPECIAL) {
-                MethodInsnNode methodNode = (MethodInsnNode)insn;
-                if (Constants.CTOR.equals(methodNode.name) && methodNode.owner.equals(newNode.desc)) {
-                    return methodNode;
-                }
-            }
-        }
-        return null;
+        return this.findInitNodeFor(newNode, null);
     }
 
     /**


### PR DESCRIPTION
Implements my requested changes from [here](https://github.com/SpongePowered/Mixin/commit/902c3439e8611fa8086e3999e62f3cd64a7b2665#commitcomment-142183895):
The only reason MixinExtras uses this method is to match Redirect's behaviour, so I would like it to be kept in line with that. Additionally, there is nothing wrong with not checking the desc as long as you've definitely found the right `NEW` insn, which the injection point handles itself.