### PR TITLE
Fix: Remove incorrect `PUTFIELD` owner check when inspecting initialisers.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/Constructor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/Constructor.java
@@ -113,10 +113,6 @@ public class Constructor extends Target {
 
         for (AbstractInsnNode initialiserInsn : initialiser.getInsns()) {
             if (initialiserInsn.getOpcode() == Opcodes.PUTFIELD) {
-                FieldInsnNode fieldInsn = (FieldInsnNode)initialiserInsn;
-                if (!fieldInsn.owner.equals(this.targetName)) {
-                    continue;
-                }
                 this.mixinInitialisedFields.add(Constructor.fieldKey((FieldInsnNode)initialiserInsn));
             }
         }


### PR DESCRIPTION
These will never match because the LHS is the mixin name and the RHS is the target name. This restores the 0.8.5 behaviour which does not check the owner at all. We have never supported assignment expressions in initialisers until now anyway, and even if we check the owner we cannot determine whether the instruction is operating on the current *instance* without proper static analysis, so IMO there's not much point bothering.