### PR TITLE
Fix typo in comment in ClassSignature

### DIFF
--- a/src/main/java/org/spongepowered/asm/util/ClassSignature.java
+++ b/src/main/java/org/spongepowered/asm/util/ClassSignature.java
@@ -1144,7 +1144,7 @@ public class ClassSignature {
             
             other.conform(typeVars);
         } catch (IllegalStateException ex) {
-            // Oh crap, this means we couldn't conform one or more type params!
+            // Oh crap, this means we couldn't confirm one or more type params!
             ex.printStackTrace();
             return;
         }


### PR DESCRIPTION
Fixes a typo inside a comment of `org.spongepowered.asm.util.ClassSignature`. "conform" was turned into "confirm"