### PR TITLE
Fix `null` MixinEnvironment when adding configurations

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/Mixins.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixins.java
@@ -95,7 +95,7 @@ public final class Mixins {
      * @param configFile path to configuration resource
      */
     public static void addConfiguration(String configFile) {
-        Mixins.createConfiguration(configFile, null, null);
+        Mixins.createConfiguration(configFile, MixinEnvironment.getDefaultEnvironment(), null);
     }
     
     /**


### PR DESCRIPTION
Fixes what appears to be a regression introduced in f6951762a7ab505c0e02f95c0e26a691140685a9 : https://github.com/SpongePowered/Mixin/blame/4053421aa10aaac6127d969028a29c94fe3054f6/src/main/java/org/spongepowered/asm/mixin/Mixins.java#L98C8-L98C60

This issue appears to have been patched in fabric's fork, but was never propagated upstream for some reason.

It seems `null` is incorrectly supplied as the fallback mixin environment when creating a mixin configuration. This PR restores the previous behavior.

If a null mixin environment is supplied, then the mixin configuration will fail to load here, when Mixin checks if verbose debugging is enabled: https://github.com/SpongePowered/Mixin/blob/4053421aa10aaac6127d969028a29c94fe3054f6/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java#L466

Stacktrace:

```
[00:54:38.810] [main/INFO] [Fabric Loader/] Loading 7 mods:
[00:54:38.811] 	- asm 9.0
[00:54:38.811] 	- fabricloader 0.16.0
[00:54:38.811] 	   \-- mixinextras 0.4.0
[00:54:38.811] 	- java 17
[00:54:38.811] 	- mixin 0.8.7
[00:54:38.811] 	- wilderforge ${WILDERFORGE_VERSION}
[00:54:38.812] 	- wildermyth 1.16+543
[00:54:38.857] [main/INFO] [Fabric Loader/Mixin] SpongePowered MIXIN Subsystem Version=0.8.7 Source=file:/home/gamebuster/.gradle/caches/modules-2/files-2.1/org.spongepowered/mixin/0.8.7/8ab114ac385e6dbdad5efafe28aba4df8120915f/mixin-0.8.7.jar Service=Knot/Fabric Env=CLIENT
[00:54:38.864] /*********************************************************************************************************************************************************************************************************/
[00:54:38.865] /*                                                                            SpongePowered MIXIN (Verbose debugging enabled)                                                                            */
[00:54:38.866] /*********************************************************************************************************************************************************************************************************/
[00:54:38.867] /*                                         Code source : file:/home/gamebuster/.gradle/caches/modules-2/files-2.1/org.spongepowered/mixin/0.8.7/8ab114ac385e6dbdad5efafe28aba4df8120915f/mixin-0.8.7.jar */
[00:54:38.868] /*                                    Internal Version : 0.8.7                                                                                                                                           */
[00:54:38.869] /*                                        Java Version : 17.0 (supports compatibility 6-17)                                                                                                              */
[00:54:38.870] /*                         Default Compatibility Level : JAVA_8                                                                                                                                          */
[00:54:38.871] /*                   Max Effective Compatibility Level : JAVA_13                                                                                                                                         */
[00:54:38.873] /*                                Detected ASM Version : ASM 9.7 (ASM10_EXPERIMENTAL)                                                                                                                    */
[00:54:38.874] /*                          Detected ASM Supports Java : Up to Java 23 (class file version 67.0)                                                                                                         */
[00:54:38.875] /*********************************************************************************************************************************************************************************************************/
[00:54:38.876] /*                                        Service Name : Knot/Fabric                                                                                                                                     */
[00:54:38.877] /*                                 Mixin Service Class : net.fabricmc.loader.impl.launch.knot.MixinServiceKnot                                                                                           */
[00:54:38.878] /*                       Global Property Service Class : net.fabricmc.loader.impl.launch.knot.FabricGlobalPropertyService                                                                                */
[00:54:38.879] /*                                 Logger Adapter Type : Fabric Mixin Logger                                                                                                                             */
[00:54:38.879] /*********************************************************************************************************************************************************************************************************/
[00:54:38.880] /*                                         mixin.debug : <true>                                                                                                                                          */
[00:54:38.881] /*                                  mixin.debug.export : - <true>                                                                                                                                        */
[00:54:38.882] /*                           mixin.debug.export.filter : - - <null>                                                                                                                                      */
[00:54:38.883] /*                        mixin.debug.export.decompile : - - <true>                                                                                                                                      */
[00:54:38.884] /*                  mixin.debug.export.decompile.async : - - - <true>                                                                                                                                    */
[00:54:38.885] /* mixin.debug.export.decompile.mergeGenericSignatures : - - - <true>                                                                                                                                    */
[00:54:38.886] /*                                  mixin.debug.verify : - <true>                                                                                                                                        */
[00:54:38.887] /*                                 mixin.debug.verbose : - <true>                                                                                                                                        */
[00:54:38.888] /*                         mixin.debug.countInjections : - <true>                                                                                                                                        */
[00:54:38.889] /*                                  mixin.debug.strict : - <false>                                                                                                                                       */
[00:54:38.890] /*                           mixin.debug.strict.unique : - - <false>                                                                                                                                     */
[00:54:38.891] /*                          mixin.debug.strict.targets : - - <false>                                                                                                                                     */
[00:54:38.891] /*                                mixin.debug.profiler : - <true>                                                                                                                                        */
[00:54:38.892] /*                           mixin.dumpTargetOnFailure : <true>                                                                                                                                          */
[00:54:38.893] /*                                        mixin.checks : <false>                                                                                                                                         */
[00:54:38.894] /*                             mixin.checks.interfaces : - <false>                                                                                                                                       */
[00:54:38.895] /*                      mixin.checks.interfaces.strict : - - <false>                                                                                                                                     */
[00:54:38.896] /*                             mixin.ignoreConstraints : <false>                                                                                                                                         */
[00:54:38.897] /*                                       mixin.hotSwap : <false>                                                                                                                                         */
[00:54:38.898] /*                                       mixin.env.obf : - <false>                                                                                                                                       */
[00:54:38.899] /*                             mixin.env.disableRefMap : - <false>                                                                                                                                       */
[00:54:38.900] /*                               mixin.env.remapRefMap : - <false>                                                                                                                                       */
[00:54:38.901] /*                       mixin.env.refMapRemappingFile : - <>                                                                                                                                            */
[00:54:38.901] /*                        mixin.env.refMapRemappingEnv : - <searge>                                                                                                                                      */
[00:54:38.902] /*                      mixin.env.allowPermissiveMatch : - <false>                                                                                                                                       */
[00:54:38.903] /*                            mixin.env.ignoreRequired : - <false>                                                                                                                                       */
[00:54:38.904] /*                               mixin.env.compatLevel : - <false>                                                                                                                                       */
[00:54:38.905] /*                          mixin.env.shiftByViolation : - <warn>                                                                                                                                        */
[00:54:38.906] /*                      mixin.initialiserInjectionMode : <default>                                                                                                                                       */
[00:54:38.907] /*               mixin.tunable.classReaderExpandFrames : - <false>                                                                                                                                       */
[00:54:38.908] /*********************************************************************************************************************************************************************************************************/
[00:54:38.909] /*                                    UNSAFE_INJECTION : available=<true> enabled=<true>                                                                                                                 */
[00:54:38.910] /*                       INJECTORS_IN_INTERFACE_MIXINS : available=<true> enabled=<true>                                                                                                                 */
[00:54:38.911] /*********************************************************************************************************************************************************************************************************/
[00:54:38.912] /*                                       Detected Side : CLIENT                                                                                                                                          */
[00:54:38.913] /*********************************************************************************************************************************************************************************************************/
[00:54:38.922] [main/INFO] [Fabric Loader/Mixin] Attempting to load Fernflower decompiler (Threaded mode)
[00:54:38.923] [main/INFO] [Fabric Loader/Mixin] Fernflower could not be loaded, exported classes will not be decompiled. NoClassDefFoundError: org/jetbrains/java/decompiler/main/extern/IResultSaver
[00:54:38.957] [main/ERROR] [Fabric Loader/] Catching java.lang.RuntimeException: Error creating Mixin config mixinextras.init.mixins.json for mod mixinextras
[00:54:38.957] 	at net.fabricmc.loader.impl.launch.FabricMixinBootstrap.init(FabricMixinBootstrap.java:96)
[00:54:38.958] 	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:151)
[00:54:38.958] 	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68)
[00:54:38.958] 	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
[00:54:38.959] 	at com.wildermods.wilderloader.Main.main(Main.java:77)
[00:54:38.959] Caused by: org.spongepowered.asm.launch.MixinInitialisationError: Error initialising mixin config mixinextras.init.mixins.json
[00:54:38.960] 	at org.spongepowered.asm.mixin.transformer.Config.create(Config.java:168)
[00:54:38.960] 	at org.spongepowered.asm.mixin.Mixins.createConfiguration(Mixins.java:121)
[00:54:38.960] 	at org.spongepowered.asm.mixin.Mixins.addConfiguration(Mixins.java:98)
[00:54:38.961] 	at net.fabricmc.loader.impl.launch.FabricMixinBootstrap.init(FabricMixinBootstrap.java:94)
[00:54:38.961] 	... 4 more
[00:54:38.961] Caused by: java.lang.IllegalArgumentException: The specified resource 'mixinextras.init.mixins.json' was invalid or could not be read
[00:54:38.962] 	at org.spongepowered.asm.mixin.transformer.MixinConfig.create(MixinConfig.java:1398)
[00:54:38.962] 	at org.spongepowered.asm.mixin.transformer.Config.create(Config.java:163)
[00:54:38.962] 	... 7 more
[00:54:38.962] Caused by: java.lang.NullPointerException: Cannot invoke "org.spongepowered.asm.mixin.MixinEnvironment.getOption(org.spongepowered.asm.mixin.MixinEnvironment$Option)" because "this.env" is null
[00:54:38.963] 	at org.spongepowered.asm.mixin.transformer.MixinConfig.onLoad(MixinConfig.java:466)
[00:54:38.964] 	at org.spongepowered.asm.mixin.transformer.MixinConfig.create(MixinConfig.java:1391)
[00:54:38.964] 	... 8 more
```